### PR TITLE
Fix: KryptonComboBox does not follow theme settings when DropDownStyle is DropDownList

### DIFF
--- a/Applications/Source/Palette Designer/Pages/InputControls.cs
+++ b/Applications/Source/Palette Designer/Pages/InputControls.cs
@@ -40,7 +40,9 @@ namespace PaletteDesigner.Pages
                 comboBoxDisabled,
                 comboBoxDisabled2,
                 comboBoxNormal,
-                comboBoxActive
+                comboBoxNormal2,
+                comboBoxActive,
+                comboBoxActive2
             });
             numericUpDowns = new List<KryptonNumericUpDown>( new[]
             {


### PR DESCRIPTION
Fix for issue "KryptonComboBox does not follow theme settings when DropDownStyle is DropDownList" #751.

In the Palette Designer it is not possible to change the KryptonComboBox controls with DropDownStyle = DropDownList.
The issue seems to be that these controls for state Normal and Active are not updated when the Palette is...

This PR fixes this...