### PR TITLE
(chore) Refactor Palette Designer and Upgrade Tool (V100)

### DIFF
--- a/Applications/Source/Palette Designer/FormChromeRibbon.cs
+++ b/Applications/Source/Palette Designer/FormChromeRibbon.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/FormChromeTMS.cs
+++ b/Applications/Source/Palette Designer/FormChromeTMS.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  *  
  */
 #endregion

--- a/Applications/Source/Palette Designer/FormPaletteUpgradeTool.Designer.cs
+++ b/Applications/Source/Palette Designer/FormPaletteUpgradeTool.Designer.cs
@@ -47,6 +47,8 @@
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.kcmdBrowseForOriginalFile = new Krypton.Toolkit.KryptonCommand();
+            this.kbtnBrowseInput = new Krypton.Toolkit.KryptonButton();
+            this.kbtnBrowseOutput = new Krypton.Toolkit.KryptonButton();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).BeginInit();
@@ -56,9 +58,9 @@
             this.kryptonPanel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kryptonComboBox1);
             this.kryptonPanel1.Controls.Add(this.kbtnUpgrade);
             this.kryptonPanel1.Controls.Add(this.kbtnCancel);
@@ -70,9 +72,9 @@
             this.kryptonPanel1.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonPanel1.Size = new System.Drawing.Size(905, 62);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
             // kryptonComboBox1
-            // 
+            //
             this.kryptonComboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.kryptonComboBox1.DropDownWidth = 121;
             this.kryptonComboBox1.IntegralHeight = false;
@@ -83,9 +85,9 @@
             this.kryptonComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonComboBox1.TabIndex = 3;
             this.kryptonComboBox1.Visible = false;
-            // 
+            //
             // kbtnUpgrade
-            // 
+            //
             this.kbtnUpgrade.Enabled = false;
             this.kbtnUpgrade.Location = new System.Drawing.Point(639, 15);
             this.kbtnUpgrade.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -95,9 +97,9 @@
             this.kbtnUpgrade.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnUpgrade.Values.Text = "&Upgrade";
             this.kbtnUpgrade.Click += new System.EventHandler(this.kbtnUpgrade_Click);
-            // 
+            //
             // kbtnCancel
-            // 
+            //
             this.kbtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.kbtnCancel.Location = new System.Drawing.Point(767, 16);
             this.kbtnCancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -107,9 +109,9 @@
             this.kbtnCancel.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnCancel.Values.Text = "Cance&l";
             this.kbtnCancel.Click += new System.EventHandler(this.kbtnCancel_Click);
-            // 
+            //
             // kryptonBorderEdge1
-            // 
+            //
             this.kryptonBorderEdge1.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
             this.kryptonBorderEdge1.Dock = System.Windows.Forms.DockStyle.Top;
             this.kryptonBorderEdge1.Location = new System.Drawing.Point(0, 0);
@@ -117,49 +119,49 @@
             this.kryptonBorderEdge1.Name = "kryptonBorderEdge1";
             this.kryptonBorderEdge1.Size = new System.Drawing.Size(905, 1);
             this.kryptonBorderEdge1.Text = "kryptonBorderEdge1";
-            // 
+            //
             // kryptonPanel2
-            // 
+            //
             this.kryptonPanel2.Controls.Add(this.krtbInput);
             this.kryptonPanel2.Controls.Add(this.krtbOutput);
             this.kryptonPanel2.Controls.Add(this.klblStatus);
             this.kryptonPanel2.Controls.Add(this.kryptonLabel3);
             this.kryptonPanel2.Controls.Add(this.kryptonLabel2);
             this.kryptonPanel2.Controls.Add(this.kryptonPanel3);
+            this.kryptonPanel2.Controls.Add(this.kbtnBrowseInput);
+            this.kryptonPanel2.Controls.Add(this.kbtnBrowseOutput);
             this.kryptonPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel2.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPanel2.Name = "kryptonPanel2";
             this.kryptonPanel2.Size = new System.Drawing.Size(905, 494);
             this.kryptonPanel2.TabIndex = 1;
-            // 
+            //
             // krtbInput
-            // 
-            this.krtbInput.ButtonSpecs.Add(this.bsaBrowseForOriginal);
+            //
             this.krtbInput.Location = new System.Drawing.Point(17, 164);
             this.krtbInput.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.krtbInput.Name = "krtbInput";
             this.krtbInput.Size = new System.Drawing.Size(869, 118);
             this.krtbInput.TabIndex = 7;
             this.krtbInput.Text = "";
-            // 
+            //
             // bsaBrowseForOriginal
-            // 
+            //
             this.bsaBrowseForOriginal.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.bsaBrowseForOriginal.KryptonCommand = this.kcmdBrowseForUpgradedFile;
             this.bsaBrowseForOriginal.Text = "Browse";
             this.bsaBrowseForOriginal.UniqueName = "bb6174a6bb674e219e076702012a00aa";
             this.bsaBrowseForOriginal.Click += new System.EventHandler(this.bsaBrowseForOriginal_Click);
-            // 
+            //
             // kcmdBrowseForUpgradedFile
-            // 
+            //
             this.kcmdBrowseForUpgradedFile.AssignedButtonSpec = this.buttonSpecAny1;
             this.kcmdBrowseForUpgradedFile.Text = "&...";
             this.kcmdBrowseForUpgradedFile.Execute += new System.EventHandler(this.kcmdBrowseForUpgradedFile_Execute);
-            // 
+            //
             // krtbOutput
-            // 
-            this.krtbOutput.ButtonSpecs.Add(this.buttonSpecAny1);
+            //
             this.krtbOutput.Location = new System.Drawing.Point(17, 321);
             this.krtbOutput.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.krtbOutput.Name = "krtbOutput";
@@ -167,15 +169,15 @@
             this.krtbOutput.TabIndex = 6;
             this.krtbOutput.Text = "";
             this.krtbOutput.TextChanged += new System.EventHandler(this.krtbOutput_TextChanged);
-            // 
+            //
             // buttonSpecAny1
-            // 
+            //
             this.buttonSpecAny1.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny1.KryptonCommand = this.kcmdBrowseForUpgradedFile;
             this.buttonSpecAny1.UniqueName = "bb6174a6bb674e219e076702012a00aa";
-            // 
+            //
             // klblStatus
-            // 
+            //
             this.klblStatus.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
             this.klblStatus.Location = new System.Drawing.Point(17, 447);
             this.klblStatus.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -186,9 +188,9 @@
             this.klblStatus.StateCommon.ShortText.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.klblStatus.TabIndex = 5;
             this.klblStatus.Values.Text = "kryptonLabel4";
-            // 
+            //
             // kryptonLabel3
-            // 
+            //
             this.kryptonLabel3.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
             this.kryptonLabel3.Location = new System.Drawing.Point(17, 289);
             this.kryptonLabel3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -196,9 +198,9 @@
             this.kryptonLabel3.Size = new System.Drawing.Size(168, 24);
             this.kryptonLabel3.TabIndex = 3;
             this.kryptonLabel3.Values.Text = "Upgraded Palette File";
-            // 
+            //
             // kryptonLabel2
-            // 
+            //
             this.kryptonLabel2.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
             this.kryptonLabel2.Location = new System.Drawing.Point(17, 132);
             this.kryptonLabel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -206,9 +208,9 @@
             this.kryptonLabel2.Size = new System.Drawing.Size(154, 24);
             this.kryptonLabel2.TabIndex = 1;
             this.kryptonLabel2.Values.Text = "Original Palette File";
-            // 
+            //
             // kryptonPanel3
-            // 
+            //
             this.kryptonPanel3.Controls.Add(this.kryptonLabel1);
             this.kryptonPanel3.Controls.Add(this.pictureBox1);
             this.kryptonPanel3.Dock = System.Windows.Forms.DockStyle.Top;
@@ -218,9 +220,9 @@
             this.kryptonPanel3.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlCustom1;
             this.kryptonPanel3.Size = new System.Drawing.Size(905, 123);
             this.kryptonPanel3.TabIndex = 0;
-            // 
+            //
             // kryptonLabel1
-            // 
+            //
             this.kryptonLabel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
             this.kryptonLabel1.Location = new System.Drawing.Point(0, 0);
@@ -229,9 +231,9 @@
             this.kryptonLabel1.Size = new System.Drawing.Size(772, 123);
             this.kryptonLabel1.TabIndex = 1;
             this.kryptonLabel1.Values.Text = "Palette Upgrade Tool";
-            // 
+            //
             // pictureBox1
-            // 
+            //
             this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
             this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Right;
             this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
@@ -242,14 +244,34 @@
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.pictureBox1.TabIndex = 0;
             this.pictureBox1.TabStop = false;
-            // 
+            //
             // kcmdBrowseForOriginalFile
-            // 
+            //
             this.kcmdBrowseForOriginalFile.Text = "&...";
             this.kcmdBrowseForOriginalFile.Execute += new System.EventHandler(this.kcmdBrowseForOriginalFile_Execute);
-            // 
+            //
+            // kbtnBrowseInput
+            //
+            this.kbtnBrowseInput.Location = new System.Drawing.Point(793, 128);
+            this.kbtnBrowseInput.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnBrowseInput.Name = "kbtnBrowseInput";
+            this.kbtnBrowseInput.Size = new System.Drawing.Size(93, 28);
+            this.kbtnBrowseInput.TabIndex = 8;
+            this.kbtnBrowseInput.Values.Text = "Browse...";
+            this.kbtnBrowseInput.Click += new System.EventHandler(this.kcmdBrowseForOriginalFile_Execute);
+            //
+            // kbtnBrowseOutput
+            //
+            this.kbtnBrowseOutput.Location = new System.Drawing.Point(793, 285);
+            this.kbtnBrowseOutput.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnBrowseOutput.Name = "kbtnBrowseOutput";
+            this.kbtnBrowseOutput.Size = new System.Drawing.Size(93, 28);
+            this.kbtnBrowseOutput.TabIndex = 9;
+            this.kbtnBrowseOutput.Values.Text = "Browse...";
+            this.kbtnBrowseOutput.Click += new System.EventHandler(this.kcmdBrowseForUpgradedFile_Execute);
+            //
             // FormPaletteUpgradeTool
-            // 
+            //
             this.AcceptButton = this.kbtnUpgrade;
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -302,5 +324,7 @@
         private ButtonSpecAny buttonSpecAny1;
         private KryptonRichTextBox krtbInput;
         private ButtonSpecAny bsaBrowseForOriginal;
+        private KryptonButton kbtnBrowseInput;
+        private KryptonButton kbtnBrowseOutput;
     }
 }

--- a/Applications/Source/Palette Designer/FormPaletteUpgradeTool.cs
+++ b/Applications/Source/Palette Designer/FormPaletteUpgradeTool.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2024. All rights reserved.
  */
 #endregion
 
@@ -93,23 +93,17 @@ namespace PaletteDesigner
         /// <param name="transform">The transform.</param>
         /// <param name="xml">The XML.</param>
         /// <returns></returns>
-        private string TransformXml(XslCompiledTransform transform, string xml)
+        private static string TransformXml(XslCompiledTransform transform, string xml)
         {
-            StringReader reader = new StringReader(xml);
-
-            StringWriter writer = new StringWriter();
-
-            XmlTextReader xmlTextReader = new XmlTextReader(reader);
-
-            XmlTextWriter xmlTextWriter = new XmlTextWriter(writer)
+            using (var reader = new StringReader(xml))
+            using (var writer = new StringWriter())
+            using (var xmlReader = new XmlTextReader(reader))
+            using (var xmlWriter = new XmlTextWriter(writer) { Formatting = Formatting.Indented, Indentation = 4 })
             {
-                Formatting = Formatting.Indented,
-                Indentation = 4
-            };
+                transform.Transform(xmlReader, xmlWriter);
 
-            transform.Transform(xmlTextReader, xmlTextWriter);
-
-            return writer.ToString();
+                return writer.ToString();
+            }
         }
 
         /// <summary>
@@ -209,42 +203,41 @@ namespace PaletteDesigner
         {
             try
             {
-                var reader = new StreamReader(krtbInput.Text);
+                // Read the original palette XML
+                string xml;
+                using (var reader = new StreamReader(krtbInput.Text))
+                {
+                    xml = reader.ReadToEnd();
+                }
 
-                string end = reader.ReadToEnd();
-
-                reader.Close();
-
+                // Apply the required transformation(s)
                 if (GetInputVersionNumber() < 6)
                 {
-                    var xslCompiledTransform = new XslCompiledTransform();
-
-                    xslCompiledTransform.Load(new XmlTextReader(new StringReader(Resources.v2to6)));
-                    end = TransformXml(xslCompiledTransform, end);
+                    var transform = new XslCompiledTransform();
+                    transform.Load(new XmlTextReader(new StringReader(Resources.v2to6)));
+                    xml = TransformXml(transform, xml);
                 }
                 else if (GetInputVersionNumber() < MAXIMUM_PALETTE_FILE_VERSION)
                 {
-                    var streamReader = new StringReader(Resources.v6to20);
-                    var xmlTextReader = XmlReader.Create(streamReader);
-                    var xslCompiledTransform1 = new XslCompiledTransform();
-                    xslCompiledTransform1.Load(xmlTextReader);
-                    end = TransformXml(xslCompiledTransform1, end);
+                    var transform = new XslCompiledTransform();
+                    using (var sr = new StringReader(Resources.v6to20))
+                    using (var xr = XmlReader.Create(sr))
+                    {
+                        transform.Load(xr);
+                    }
+                    xml = TransformXml(transform, xml);
                 }
 
-                var writer = new StreamWriter(krtbOutput.Text);
+                // Write the upgraded XML to the chosen output file
+                using (var writer = new StreamWriter(krtbOutput.Text, false))
+                {
+                    writer.WriteLine("<?xml version=\"1.0\"?>");
+                    writer.Write(xml);
+                }
 
-                writer.WriteLine("<?xml version=\"1.0\"?>");
+                string message = $"Input file: {krtbInput.Text}\nOutput file: {krtbOutput.Text}\n\nUpgrade from version '{_inputVersionNumber}' to version '{MAXIMUM_PALETTE_FILE_VERSION}' has succeeded.";
 
-                writer.Write(end);
-
-                writer.Flush();
-
-                writer.Close();
-
-                object[] text = ["Input file: ", krtbInput.Text, "\nOutput file: ", krtbOutput.Text, "\n\nUpgrade from version '", _inputVersionNumber, "' to version '", MAXIMUM_PALETTE_FILE_VERSION.ToString(), "' has succeeded."
-                ];
-
-                KryptonMessageBox.Show(this, string.Concat(text), "Upgrade Success", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                KryptonMessageBox.Show(this, message, "Upgrade Success", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
 
                 kbtnUpgrade.Enabled = false;
             }
@@ -258,8 +251,8 @@ namespace PaletteDesigner
         {
             KryptonOpenFileDialog openFileDialog = new()
             {
-                Title = @"Open a Existing Krypton Palette File:",
-                Filter = @"Krypton Palette XML Files (*.xml)|*.xml"
+                Title = @"Open an existing Krypton palette file:",
+                Filter = @"Krypton palette XML files (*.xml)|*.xml"
             };
 
             if (openFileDialog.ShowDialog() == DialogResult.OK)
@@ -293,27 +286,11 @@ namespace PaletteDesigner
 
                             SetInputVersionNumber(paletteFileVersionNumber);
 
-                            FileInfo fileInfo = new FileInfo(openFileDialog.FileName);
+                            string directoryName = Path.GetDirectoryName(openFileDialog.FileName) ?? string.Empty;
+                            string baseName = Path.GetFileNameWithoutExtension(openFileDialog.FileName);
+                            string extension = Path.GetExtension(openFileDialog.FileName);
 
-                            if (fileInfo != null)
-                            {
-                                string str = (fileInfo.Name.IndexOf(fileInfo.Extension) <= 0 ? fileInfo.Name : fileInfo.Name.Substring(0, fileInfo.Name.IndexOf(fileInfo.Extension)));
-
-                                string directoryName = fileInfo.DirectoryName;
-
-                                if (!directoryName.EndsWith("\\"))
-                                {
-                                    directoryName = string.Concat(directoryName, "\\");
-                                }
-
-                                KryptonRichTextBox richTextBox = krtbOutput;
-
-                                string[] strArrays = [directoryName, str, "_v", (MAXIMUM_PALETTE_FILE_VERSION + 1).ToString(), fileInfo.Extension
-                                ];
-
-                                richTextBox.Text = string.Concat(strArrays);
-                            }
-
+                            krtbOutput.Text = Path.Combine(directoryName, $"{baseName}_v{MAXIMUM_PALETTE_FILE_VERSION}{extension}");
                             break;
                         }
                     default:
@@ -348,19 +325,15 @@ namespace PaletteDesigner
         {
             KryptonSaveFileDialog saveFileDialog = new()
             {
-                Title = @"Save Krypton Palette File:",
-                Filter = @"Krypton Palette XML Files (*.xml)|*.xml"
+                Title = @"Save Krypton palette file as:",
+                Filter = @"Krypton palette XML files (*.xml)|*.xml",
+                InitialDirectory = Path.GetDirectoryName(krtbOutput.Text),
+                FileName = Path.GetFileName(krtbOutput.Text)
             };
 
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
             {
-                var writer = new StreamWriter(Path.GetFullPath(saveFileDialog.FileName));
-
-                writer.Write(krtbOutput.Text);
-
-                writer.Close();
-
-                writer.Dispose();
+                krtbOutput.Text = Path.GetFullPath(saveFileDialog.FileName);
             }
         }
     }

--- a/Applications/Source/Palette Designer/FormPaletteUpgradeTool.cs
+++ b/Applications/Source/Palette Designer/FormPaletteUpgradeTool.cs
@@ -1,7 +1,10 @@
 ﻿#region BSD License
 /*
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 
@@ -96,8 +99,11 @@ namespace PaletteDesigner
         private static string TransformXml(XslCompiledTransform transform, string xml)
         {
             using (var reader = new StringReader(xml))
+
             using (var writer = new StringWriter())
+
             using (var xmlReader = new XmlTextReader(reader))
+
             using (var xmlWriter = new XmlTextWriter(writer) { Formatting = Formatting.Indented, Indentation = 4 })
             {
                 transform.Transform(xmlReader, xmlWriter);
@@ -220,7 +226,9 @@ namespace PaletteDesigner
                 else if (GetInputVersionNumber() < MAXIMUM_PALETTE_FILE_VERSION)
                 {
                     var transform = new XslCompiledTransform();
+
                     using (var sr = new StringReader(Resources.v6to20))
+
                     using (var xr = XmlReader.Create(sr))
                     {
                         transform.Load(xr);

--- a/Applications/Source/Palette Designer/FormXMLViewer.cs
+++ b/Applications/Source/Palette Designer/FormXMLViewer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/MainForm.Designer.cs
+++ b/Applications/Source/Palette Designer/MainForm.Designer.cs
@@ -210,9 +210,6 @@ namespace PaletteDesigner
             this.pageDesignChromeTMS = new Krypton.Navigator.KryptonPage();
             this.pageDesignGrid = new Krypton.Navigator.KryptonPage();
             this.dataGridViewDisabled = new Krypton.Toolkit.KryptonDataGridView();
-            this.column1DataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.column2DataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.column3DataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataSetGrid = new System.Data.DataSet();
             this.dataTable1 = new System.Data.DataTable();
             this.dataColumn1 = new System.Data.DataColumn();
@@ -222,9 +219,6 @@ namespace PaletteDesigner
             this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.dataGridViewNormal = new Krypton.Toolkit.KryptonDataGridView();
-            this.column1DataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.column2DataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.column3DataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.kryptonNavigatorDesignGrids = new Krypton.Navigator.KryptonNavigator();
             this.kryptonGridList = new Krypton.Navigator.KryptonPage();
             this.kryptonGridSheet = new Krypton.Navigator.KryptonPage();
@@ -382,6 +376,12 @@ namespace PaletteDesigner
             this.kryptonPage1 = new Krypton.Navigator.KryptonPage();
             this.kryptonCheckSetLabels = new Krypton.Toolkit.KryptonCheckSet(this.components);
             this.kryptonCheckSet1 = new Krypton.Toolkit.KryptonCheckSet(this.components);
+            this.kryptonDataGridViewTextBoxColumn1 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.kryptonDataGridViewTextBoxColumn2 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.kryptonDataGridViewTextBoxColumn3 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.kryptonDataGridViewTextBoxColumn4 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.kryptonDataGridViewTextBoxColumn5 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.kryptonDataGridViewTextBoxColumn6 = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
             this.mainMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonNavigatorTop)).BeginInit();
             this.kryptonNavigatorTop.SuspendLayout();
@@ -658,8 +658,8 @@ namespace PaletteDesigner
             this.optionsToolStripMenuItem});
             this.mainMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.mainMenuStrip.Name = "mainMenuStrip";
-            this.mainMenuStrip.Padding = new System.Windows.Forms.Padding(5, 2, 0, 2);
-            this.mainMenuStrip.Size = new System.Drawing.Size(1544, 28);
+            this.mainMenuStrip.Padding = new System.Windows.Forms.Padding(4, 2, 0, 2);
+            this.mainMenuStrip.Size = new System.Drawing.Size(1162, 24);
             this.mainMenuStrip.TabIndex = 0;
             this.mainMenuStrip.Text = "menuStrip";
             // 
@@ -676,7 +676,7 @@ namespace PaletteDesigner
             this.toolStripMenuItem1,
             this.menuExit});
             this.menuFile.Name = "menuFile";
-            this.menuFile.Size = new System.Drawing.Size(46, 24);
+            this.menuFile.Size = new System.Drawing.Size(37, 20);
             this.menuFile.Text = "File";
             // 
             // menuNew
@@ -685,7 +685,7 @@ namespace PaletteDesigner
             this.menuNew.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.menuNew.Name = "menuNew";
             this.menuNew.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.menuNew.Size = new System.Drawing.Size(192, 26);
+            this.menuNew.Size = new System.Drawing.Size(155, 22);
             this.menuNew.Text = "New";
             this.menuNew.Click += new System.EventHandler(this.MenuNew_Click);
             // 
@@ -695,14 +695,14 @@ namespace PaletteDesigner
             this.menuOpen.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.menuOpen.Name = "menuOpen";
             this.menuOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.menuOpen.Size = new System.Drawing.Size(192, 26);
+            this.menuOpen.Size = new System.Drawing.Size(155, 22);
             this.menuOpen.Text = "Open...";
             this.menuOpen.Click += new System.EventHandler(this.MenuOpen_Click);
             // 
             // menuSep1
             // 
             this.menuSep1.Name = "menuSep1";
-            this.menuSep1.Size = new System.Drawing.Size(189, 6);
+            this.menuSep1.Size = new System.Drawing.Size(152, 6);
             // 
             // menuSave
             // 
@@ -710,7 +710,7 @@ namespace PaletteDesigner
             this.menuSave.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.menuSave.Name = "menuSave";
             this.menuSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.menuSave.Size = new System.Drawing.Size(192, 26);
+            this.menuSave.Size = new System.Drawing.Size(155, 22);
             this.menuSave.Text = "Save";
             this.menuSave.Click += new System.EventHandler(this.MenuSave_Click);
             // 
@@ -719,30 +719,30 @@ namespace PaletteDesigner
             this.menuSaveAs.Image = ((System.Drawing.Image)(resources.GetObject("menuSaveAs.Image")));
             this.menuSaveAs.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.menuSaveAs.Name = "menuSaveAs";
-            this.menuSaveAs.Size = new System.Drawing.Size(192, 26);
+            this.menuSaveAs.Size = new System.Drawing.Size(155, 22);
             this.menuSaveAs.Text = "Save As...";
             this.menuSaveAs.Click += new System.EventHandler(this.MenuSaveAs_Click);
             // 
             // menuSep2
             // 
             this.menuSep2.Name = "menuSep2";
-            this.menuSep2.Size = new System.Drawing.Size(189, 6);
+            this.menuSep2.Size = new System.Drawing.Size(152, 6);
             // 
             // recentThemesToolStripMenuItem
             // 
             this.recentThemesToolStripMenuItem.Name = "recentThemesToolStripMenuItem";
-            this.recentThemesToolStripMenuItem.Size = new System.Drawing.Size(192, 26);
+            this.recentThemesToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
             this.recentThemesToolStripMenuItem.Text = "&Recent Themes";
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(189, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(152, 6);
             // 
             // menuExit
             // 
             this.menuExit.Name = "menuExit";
-            this.menuExit.Size = new System.Drawing.Size(192, 26);
+            this.menuExit.Size = new System.Drawing.Size(155, 22);
             this.menuExit.Text = "Exit";
             this.menuExit.Click += new System.EventHandler(this.MenuExit_Click);
             // 
@@ -753,26 +753,26 @@ namespace PaletteDesigner
             this.toolStripMenuItem2,
             this.settingsToolStripMenuItem});
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(75, 24);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.optionsToolStripMenuItem.Text = "&Options";
             // 
             // launchPaletteUpgradeToolToolStripMenuItem
             // 
             this.launchPaletteUpgradeToolToolStripMenuItem.Name = "launchPaletteUpgradeToolToolStripMenuItem";
-            this.launchPaletteUpgradeToolToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
+            this.launchPaletteUpgradeToolToolStripMenuItem.Size = new System.Drawing.Size(229, 26);
             this.launchPaletteUpgradeToolToolStripMenuItem.Text = "Launch Palette &Upgrade Tool";
             this.launchPaletteUpgradeToolToolStripMenuItem.Click += new System.EventHandler(this.LaunchPaletteUpgradeToolToolStripMenuItem_Click);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(279, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(226, 6);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("settingsToolStripMenuItem.Image")));
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(229, 26);
             this.settingsToolStripMenuItem.Text = "Se&ttings";
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.SettingsToolStripMenuItem_Click);
             // 
@@ -792,9 +792,7 @@ namespace PaletteDesigner
             this.kryptonNavigatorTop.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
             this.kryptonNavigatorTop.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorTop.Dock = System.Windows.Forms.DockStyle.Top;
-            this.kryptonNavigatorTop.Location = new System.Drawing.Point(0, 28);
-            this.kryptonNavigatorTop.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorTop.Name = "kryptonNavigatorTop";
+            this.kryptonNavigatorTop.Location = new System.Drawing.Point(0, 24);
             this.kryptonNavigatorTop.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorTop.Owner = null;
             this.kryptonNavigatorTop.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -821,7 +819,7 @@ namespace PaletteDesigner
             this.pageTopMenuItems,
             this.pageTopToolTips});
             this.kryptonNavigatorTop.SelectedIndex = 0;
-            this.kryptonNavigatorTop.Size = new System.Drawing.Size(1544, 55);
+            this.kryptonNavigatorTop.Size = new System.Drawing.Size(1162, 51);
             this.kryptonNavigatorTop.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorTop.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5, 5, 5, 0);
             this.kryptonNavigatorTop.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -841,10 +839,9 @@ namespace PaletteDesigner
             this.pageTopRibbon.Flags = 65535;
             this.pageTopRibbon.ImageSmall = global::PaletteDesigner.Properties.Resources.TopRibbon;
             this.pageTopRibbon.LastVisibleSet = true;
-            this.pageTopRibbon.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopRibbon.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopRibbon.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopRibbon.Name = "pageTopRibbon";
-            this.pageTopRibbon.Size = new System.Drawing.Size(133, 123);
+            this.pageTopRibbon.Size = new System.Drawing.Size(100, 100);
             this.pageTopRibbon.Text = "Ribbon";
             this.pageTopRibbon.ToolTipTitle = "Page ToolTip";
             this.pageTopRibbon.UniqueName = "F7A49B746D4C486AF7A49B746D4C486A";
@@ -855,10 +852,10 @@ namespace PaletteDesigner
             this.pageTopLists.Flags = 65534;
             this.pageTopLists.ImageSmall = global::PaletteDesigner.Properties.Resources.KryptonGActual;
             this.pageTopLists.LastVisibleSet = true;
-            this.pageTopLists.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.pageTopLists.MinimumSize = new System.Drawing.Size(51, 50);
+            this.pageTopLists.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pageTopLists.MinimumSize = new System.Drawing.Size(38, 41);
             this.pageTopLists.Name = "pageTopLists";
-            this.pageTopLists.Size = new System.Drawing.Size(100, 100);
+            this.pageTopLists.Size = new System.Drawing.Size(75, 81);
             this.pageTopLists.Text = "Lists";
             this.pageTopLists.ToolTipTitle = "Page ToolTip";
             this.pageTopLists.UniqueName = "f7b778d5010243c187721c2618d605fe";
@@ -871,10 +868,9 @@ namespace PaletteDesigner
             this.pageTopControls.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopControls.ImageMedium")));
             this.pageTopControls.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopControls.ImageSmall")));
             this.pageTopControls.LastVisibleSet = true;
-            this.pageTopControls.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopControls.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopControls.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopControls.Name = "pageTopControls";
-            this.pageTopControls.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopControls.Size = new System.Drawing.Size(787, 50);
             this.pageTopControls.Text = "Controls";
             this.pageTopControls.ToolTipTitle = "Page ToolTip";
             this.pageTopControls.UniqueName = "3BAC6637703940CB3BAC6637703940CB";
@@ -885,10 +881,9 @@ namespace PaletteDesigner
             this.pageTopInputControls.Flags = 65535;
             this.pageTopInputControls.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopInputControls.ImageSmall")));
             this.pageTopInputControls.LastVisibleSet = true;
-            this.pageTopInputControls.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopInputControls.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopInputControls.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopInputControls.Name = "pageTopInputControls";
-            this.pageTopInputControls.Size = new System.Drawing.Size(133, 123);
+            this.pageTopInputControls.Size = new System.Drawing.Size(100, 100);
             this.pageTopInputControls.Text = "Input Controls";
             this.pageTopInputControls.ToolTipTitle = "Page ToolTip";
             this.pageTopInputControls.UniqueName = "D367C5BB74D04696D367C5BB74D04696";
@@ -901,10 +896,9 @@ namespace PaletteDesigner
             this.pageTopButtonSpecs.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopButtonSpecs.ImageMedium")));
             this.pageTopButtonSpecs.ImageSmall = global::PaletteDesigner.Properties.Resources.TopBS;
             this.pageTopButtonSpecs.LastVisibleSet = true;
-            this.pageTopButtonSpecs.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopButtonSpecs.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopButtonSpecs.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopButtonSpecs.Name = "pageTopButtonSpecs";
-            this.pageTopButtonSpecs.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopButtonSpecs.Size = new System.Drawing.Size(787, 50);
             this.pageTopButtonSpecs.Text = "ButtonSpecs";
             this.pageTopButtonSpecs.ToolTipTitle = "Page ToolTip";
             this.pageTopButtonSpecs.UniqueName = "3482463805154E213482463805154E21";
@@ -917,10 +911,9 @@ namespace PaletteDesigner
             this.pageTopButtons.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopButtons.ImageMedium")));
             this.pageTopButtons.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopButtons.ImageSmall")));
             this.pageTopButtons.LastVisibleSet = true;
-            this.pageTopButtons.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopButtons.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopButtons.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopButtons.Name = "pageTopButtons";
-            this.pageTopButtons.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopButtons.Size = new System.Drawing.Size(787, 50);
             this.pageTopButtons.Text = "Buttons";
             this.pageTopButtons.ToolTipTitle = "Page ToolTip";
             this.pageTopButtons.UniqueName = "56048893FA064ECE56048893FA064ECE";
@@ -931,10 +924,9 @@ namespace PaletteDesigner
             this.pageTopCheckBox.Flags = 65535;
             this.pageTopCheckBox.ImageSmall = global::PaletteDesigner.Properties.Resources.TopCB;
             this.pageTopCheckBox.LastVisibleSet = true;
-            this.pageTopCheckBox.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopCheckBox.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopCheckBox.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopCheckBox.Name = "pageTopCheckBox";
-            this.pageTopCheckBox.Size = new System.Drawing.Size(133, 123);
+            this.pageTopCheckBox.Size = new System.Drawing.Size(100, 100);
             this.pageTopCheckBox.Text = "CheckBox";
             this.pageTopCheckBox.ToolTipTitle = "Page ToolTip";
             this.pageTopCheckBox.UniqueName = "745B9534A0BD44F7745B9534A0BD44F7";
@@ -947,10 +939,9 @@ namespace PaletteDesigner
             this.pageTopChromeTMS.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopChromeTMS.ImageMedium")));
             this.pageTopChromeTMS.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopChromeTMS.ImageSmall")));
             this.pageTopChromeTMS.LastVisibleSet = true;
-            this.pageTopChromeTMS.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopChromeTMS.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopChromeTMS.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopChromeTMS.Name = "pageTopChromeTMS";
-            this.pageTopChromeTMS.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopChromeTMS.Size = new System.Drawing.Size(787, 50);
             this.pageTopChromeTMS.Text = "Chrome + TMS";
             this.pageTopChromeTMS.ToolTipTitle = "Page ToolTip";
             this.pageTopChromeTMS.UniqueName = "E85832DBA6CF476EE85832DBA6CF476E";
@@ -961,10 +952,9 @@ namespace PaletteDesigner
             this.pageTopGrids.Flags = 65535;
             this.pageTopGrids.ImageSmall = global::PaletteDesigner.Properties.Resources.TopGrid;
             this.pageTopGrids.LastVisibleSet = true;
-            this.pageTopGrids.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopGrids.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopGrids.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopGrids.Name = "pageTopGrids";
-            this.pageTopGrids.Size = new System.Drawing.Size(133, 123);
+            this.pageTopGrids.Size = new System.Drawing.Size(100, 100);
             this.pageTopGrids.Text = "Grids";
             this.pageTopGrids.ToolTipTitle = "Page ToolTip";
             this.pageTopGrids.UniqueName = "AF995F9D48C04DF2AF995F9D48C04DF2";
@@ -977,10 +967,9 @@ namespace PaletteDesigner
             this.pageTopHeaderGroup.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopHeaderGroup.ImageMedium")));
             this.pageTopHeaderGroup.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopHeaderGroup.ImageSmall")));
             this.pageTopHeaderGroup.LastVisibleSet = true;
-            this.pageTopHeaderGroup.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopHeaderGroup.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopHeaderGroup.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopHeaderGroup.Name = "pageTopHeaderGroup";
-            this.pageTopHeaderGroup.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopHeaderGroup.Size = new System.Drawing.Size(787, 50);
             this.pageTopHeaderGroup.Text = "HeaderGroup";
             this.pageTopHeaderGroup.ToolTipTitle = "Page ToolTip";
             this.pageTopHeaderGroup.UniqueName = "4E56EC4CBFD442284E56EC4CBFD44228";
@@ -993,10 +982,9 @@ namespace PaletteDesigner
             this.pageTopHeaders.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopHeaders.ImageMedium")));
             this.pageTopHeaders.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopHeaders.ImageSmall")));
             this.pageTopHeaders.LastVisibleSet = true;
-            this.pageTopHeaders.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopHeaders.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopHeaders.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopHeaders.Name = "pageTopHeaders";
-            this.pageTopHeaders.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopHeaders.Size = new System.Drawing.Size(787, 50);
             this.pageTopHeaders.Text = "Headers";
             this.pageTopHeaders.ToolTipTitle = "Page ToolTip";
             this.pageTopHeaders.UniqueName = "8C92BD9E0DED45D28C92BD9E0DED45D2";
@@ -1007,10 +995,9 @@ namespace PaletteDesigner
             this.pageTopDateTime.Flags = 65535;
             this.pageTopDateTime.ImageSmall = global::PaletteDesigner.Properties.Resources.TopDT;
             this.pageTopDateTime.LastVisibleSet = true;
-            this.pageTopDateTime.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopDateTime.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopDateTime.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopDateTime.Name = "pageTopDateTime";
-            this.pageTopDateTime.Size = new System.Drawing.Size(133, 123);
+            this.pageTopDateTime.Size = new System.Drawing.Size(100, 100);
             this.pageTopDateTime.Text = "Date Time";
             this.pageTopDateTime.ToolTipTitle = "Page ToolTip";
             this.pageTopDateTime.UniqueName = "26E3658BC339416626E3658BC3394166";
@@ -1023,10 +1010,9 @@ namespace PaletteDesigner
             this.pageTopLabels.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopLabels.ImageMedium")));
             this.pageTopLabels.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopLabels.ImageSmall")));
             this.pageTopLabels.LastVisibleSet = true;
-            this.pageTopLabels.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopLabels.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopLabels.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopLabels.Name = "pageTopLabels";
-            this.pageTopLabels.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopLabels.Size = new System.Drawing.Size(787, 50);
             this.pageTopLabels.Text = "Labels";
             this.pageTopLabels.ToolTipTitle = "Page ToolTip";
             this.pageTopLabels.UniqueName = "E32EFBB14A214C75E32EFBB14A214C75";
@@ -1039,10 +1025,9 @@ namespace PaletteDesigner
             this.pageTopNavigator.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopNavigator.ImageMedium")));
             this.pageTopNavigator.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopNavigator.ImageSmall")));
             this.pageTopNavigator.LastVisibleSet = true;
-            this.pageTopNavigator.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopNavigator.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopNavigator.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopNavigator.Name = "pageTopNavigator";
-            this.pageTopNavigator.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopNavigator.Size = new System.Drawing.Size(787, 50);
             this.pageTopNavigator.Text = "Navigator";
             this.pageTopNavigator.ToolTipTitle = "Page ToolTip";
             this.pageTopNavigator.UniqueName = "D7426FCF612042A2D7426FCF612042A2";
@@ -1055,10 +1040,9 @@ namespace PaletteDesigner
             this.pageTopPanels.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopPanels.ImageMedium")));
             this.pageTopPanels.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopPanels.ImageSmall")));
             this.pageTopPanels.LastVisibleSet = true;
-            this.pageTopPanels.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopPanels.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopPanels.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopPanels.Name = "pageTopPanels";
-            this.pageTopPanels.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopPanels.Size = new System.Drawing.Size(787, 50);
             this.pageTopPanels.Text = "Panels";
             this.pageTopPanels.ToolTipTitle = "Page ToolTip";
             this.pageTopPanels.UniqueName = "0E2D1DD7365B4A8F0E2D1DD7365B4A8F";
@@ -1069,10 +1053,9 @@ namespace PaletteDesigner
             this.pageTopRadioButton.Flags = 65535;
             this.pageTopRadioButton.ImageSmall = global::PaletteDesigner.Properties.Resources.TopRB;
             this.pageTopRadioButton.LastVisibleSet = true;
-            this.pageTopRadioButton.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopRadioButton.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopRadioButton.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopRadioButton.Name = "pageTopRadioButton";
-            this.pageTopRadioButton.Size = new System.Drawing.Size(133, 123);
+            this.pageTopRadioButton.Size = new System.Drawing.Size(100, 100);
             this.pageTopRadioButton.Text = "RadioButton";
             this.pageTopRadioButton.ToolTipTitle = "Page ToolTip";
             this.pageTopRadioButton.UniqueName = "E7F6061FFA694A7DE7F6061FFA694A7D";
@@ -1085,10 +1068,9 @@ namespace PaletteDesigner
             this.pageTopSeparators.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopSeparators.ImageMedium")));
             this.pageTopSeparators.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopSeparators.ImageSmall")));
             this.pageTopSeparators.LastVisibleSet = true;
-            this.pageTopSeparators.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopSeparators.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopSeparators.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopSeparators.Name = "pageTopSeparators";
-            this.pageTopSeparators.Size = new System.Drawing.Size(1049, 62);
+            this.pageTopSeparators.Size = new System.Drawing.Size(787, 50);
             this.pageTopSeparators.Text = "Separators";
             this.pageTopSeparators.ToolTipTitle = "Page ToolTip";
             this.pageTopSeparators.UniqueName = "AA052D0D183F4125AA052D0D183F4125";
@@ -1101,10 +1083,9 @@ namespace PaletteDesigner
             this.pageTopTabs.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTopTabs.ImageMedium")));
             this.pageTopTabs.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageTopTabs.ImageSmall")));
             this.pageTopTabs.LastVisibleSet = true;
-            this.pageTopTabs.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopTabs.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopTabs.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopTabs.Name = "pageTopTabs";
-            this.pageTopTabs.Size = new System.Drawing.Size(133, 123);
+            this.pageTopTabs.Size = new System.Drawing.Size(100, 100);
             this.pageTopTabs.Text = "Tabs";
             this.pageTopTabs.ToolTipTitle = "Page ToolTip";
             this.pageTopTabs.UniqueName = "461B49C26EBB4816461B49C26EBB4816";
@@ -1115,10 +1096,9 @@ namespace PaletteDesigner
             this.pageTopTrackBar.Flags = 65534;
             this.pageTopTrackBar.ImageSmall = global::PaletteDesigner.Properties.Resources.TopTrackBar2;
             this.pageTopTrackBar.LastVisibleSet = true;
-            this.pageTopTrackBar.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopTrackBar.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopTrackBar.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopTrackBar.Name = "pageTopTrackBar";
-            this.pageTopTrackBar.Size = new System.Drawing.Size(133, 123);
+            this.pageTopTrackBar.Size = new System.Drawing.Size(100, 100);
             this.pageTopTrackBar.Text = "TrackBar";
             this.pageTopTrackBar.ToolTipTitle = "Page ToolTip";
             this.pageTopTrackBar.UniqueName = "8EA51AFFC0D843D551B44BCB916273AC";
@@ -1128,10 +1108,10 @@ namespace PaletteDesigner
             this.pageTopMenuItems.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageTopMenuItems.Flags = 65534;
             this.pageTopMenuItems.LastVisibleSet = true;
-            this.pageTopMenuItems.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.pageTopMenuItems.MinimumSize = new System.Drawing.Size(51, 50);
+            this.pageTopMenuItems.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pageTopMenuItems.MinimumSize = new System.Drawing.Size(38, 41);
             this.pageTopMenuItems.Name = "pageTopMenuItems";
-            this.pageTopMenuItems.Size = new System.Drawing.Size(100, 100);
+            this.pageTopMenuItems.Size = new System.Drawing.Size(75, 81);
             this.pageTopMenuItems.Text = "Menu Items";
             this.pageTopMenuItems.ToolTipTitle = "Page ToolTip";
             this.pageTopMenuItems.UniqueName = "95c2ec35c075402bac013139a5f5b16a";
@@ -1141,10 +1121,9 @@ namespace PaletteDesigner
             this.pageTopToolTips.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageTopToolTips.Flags = 65534;
             this.pageTopToolTips.LastVisibleSet = true;
-            this.pageTopToolTips.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTopToolTips.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTopToolTips.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTopToolTips.Name = "pageTopToolTips";
-            this.pageTopToolTips.Size = new System.Drawing.Size(133, 123);
+            this.pageTopToolTips.Size = new System.Drawing.Size(100, 100);
             this.pageTopToolTips.Text = "ToolTips";
             this.pageTopToolTips.ToolTipTitle = "Page ToolTip";
             this.pageTopToolTips.UniqueName = "a5f1868720aa41f2bdba83ff2b9fb8f1";
@@ -1153,20 +1132,17 @@ namespace PaletteDesigner
             // 
             this.kryptonPanelMainFill.Controls.Add(this.kryptonSplitContainerMain);
             this.kryptonPanelMainFill.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kryptonPanelMainFill.Location = new System.Drawing.Point(0, 83);
-            this.kryptonPanelMainFill.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonPanelMainFill.Location = new System.Drawing.Point(0, 75);
             this.kryptonPanelMainFill.Name = "kryptonPanelMainFill";
-            this.kryptonPanelMainFill.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.kryptonPanelMainFill.Size = new System.Drawing.Size(1544, 747);
+            this.kryptonPanelMainFill.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.kryptonPanelMainFill.Size = new System.Drawing.Size(1162, 587);
             this.kryptonPanelMainFill.TabIndex = 2;
             // 
             // kryptonSplitContainerMain
             // 
             this.kryptonSplitContainerMain.Cursor = System.Windows.Forms.Cursors.Default;
             this.kryptonSplitContainerMain.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kryptonSplitContainerMain.Location = new System.Drawing.Point(7, 6);
-            this.kryptonSplitContainerMain.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonSplitContainerMain.Name = "kryptonSplitContainerMain";
+            this.kryptonSplitContainerMain.Location = new System.Drawing.Point(5, 5);
             // 
             // kryptonSplitContainerMain.Panel1
             // 
@@ -1178,8 +1154,8 @@ namespace PaletteDesigner
             this.kryptonSplitContainerMain.Panel2.Controls.Add(this.kryptonHeaderGroupProperties);
             this.kryptonSplitContainerMain.Panel2MinSize = 200;
             this.kryptonSplitContainerMain.SeparatorStyle = Krypton.Toolkit.SeparatorStyle.HighProfile;
-            this.kryptonSplitContainerMain.Size = new System.Drawing.Size(1530, 735);
-            this.kryptonSplitContainerMain.SplitterDistance = 859;
+            this.kryptonSplitContainerMain.Size = new System.Drawing.Size(1152, 577);
+            this.kryptonSplitContainerMain.SplitterDistance = 646;
             this.kryptonSplitContainerMain.SplitterWidth = 7;
             this.kryptonSplitContainerMain.TabIndex = 0;
             // 
@@ -1208,8 +1184,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesign.Header.HeaderValuesPrimary.MapHeading = Krypton.Navigator.MapKryptonPageText.Text;
             this.kryptonNavigatorDesign.Header.HeaderValuesPrimary.MapImage = Krypton.Navigator.MapKryptonPageImage.SmallMedium;
             this.kryptonNavigatorDesign.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesign.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesign.Name = "kryptonNavigatorDesign";
             this.kryptonNavigatorDesign.NavigatorMode = Krypton.Navigator.NavigatorMode.HeaderGroup;
             this.kryptonNavigatorDesign.Owner = null;
             this.kryptonNavigatorDesign.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -1236,7 +1210,7 @@ namespace PaletteDesigner
             this.pageDesignMenuItems,
             this.pageDesignToolTips});
             this.kryptonNavigatorDesign.SelectedIndex = 0;
-            this.kryptonNavigatorDesign.Size = new System.Drawing.Size(859, 735);
+            this.kryptonNavigatorDesign.Size = new System.Drawing.Size(646, 577);
             this.kryptonNavigatorDesign.TabIndex = 2;
             this.kryptonNavigatorDesign.Text = "kryptonNavigator1";
             this.kryptonNavigatorDesign.SelectedPageChanged += new System.EventHandler(this.KryptonNavigatorDesign_SelectedPageChanged);
@@ -1247,11 +1221,10 @@ namespace PaletteDesigner
             this.pageDesignRibbon.Flags = 65535;
             this.pageDesignRibbon.ImageSmall = global::PaletteDesigner.Properties.Resources.KryptonRibbon;
             this.pageDesignRibbon.LastVisibleSet = true;
-            this.pageDesignRibbon.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignRibbon.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignRibbon.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignRibbon.Name = "pageDesignRibbon";
-            this.pageDesignRibbon.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
-            this.pageDesignRibbon.Size = new System.Drawing.Size(857, 672);
+            this.pageDesignRibbon.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.pageDesignRibbon.Size = new System.Drawing.Size(644, 524);
             this.pageDesignRibbon.Text = "Design Ribbon";
             this.pageDesignRibbon.TextDescription = "Preview appearance of the Ribbon control.";
             this.pageDesignRibbon.TextTitle = "";
@@ -1266,29 +1239,28 @@ namespace PaletteDesigner
             this.pageLists.Controls.Add(this.kryptonGroupBox1);
             this.pageLists.Flags = 65534;
             this.pageLists.LastVisibleSet = true;
-            this.pageLists.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.pageLists.MinimumSize = new System.Drawing.Size(51, 50);
+            this.pageLists.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pageLists.MinimumSize = new System.Drawing.Size(38, 41);
             this.pageLists.Name = "pageLists";
-            this.pageLists.Size = new System.Drawing.Size(859, 670);
+            this.pageLists.Size = new System.Drawing.Size(644, 544);
             this.pageLists.Text = "List Controls";
-            this.pageLists.TextDescription = "List Control; Then the List View";
+            this.pageLists.TextDescription = "List Control, then the List View";
             this.pageLists.TextTitle = "";
             this.pageLists.ToolTipTitle = "Page ToolTip";
             this.pageLists.UniqueName = "210efe52832f430db303ff35cafe9dca";
             // 
             // kryptonGroupBox3
             // 
-            this.kryptonGroupBox3.Location = new System.Drawing.Point(21, 434);
-            this.kryptonGroupBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.kryptonGroupBox3.Name = "kryptonGroupBox3";
+            this.kryptonGroupBox3.Location = new System.Drawing.Point(16, 353);
+            this.kryptonGroupBox3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             // 
             // kryptonGroupBox3.Panel
             // 
             this.kryptonGroupBox3.Panel.Controls.Add(this.kryptonListView3);
             this.kryptonGroupBox3.Panel.Controls.Add(this.kryptonListBox3);
-            this.kryptonGroupBox3.Size = new System.Drawing.Size(801, 199);
+            this.kryptonGroupBox3.Size = new System.Drawing.Size(601, 162);
             this.kryptonGroupBox3.TabIndex = 2;
-            this.kryptonGroupBox3.Values.Heading = "Allways Active";
+            this.kryptonGroupBox3.Values.Heading = "Always Active";
             // 
             // kryptonListView3
             // 
@@ -1301,11 +1273,11 @@ namespace PaletteDesigner
             this.kryptonListView3.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem1,
             listViewItem2});
-            this.kryptonListView3.Location = new System.Drawing.Point(212, 14);
-            this.kryptonListView3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListView3.Location = new System.Drawing.Point(159, 11);
+            this.kryptonListView3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListView3.Name = "kryptonListView3";
             this.kryptonListView3.PaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonListView3.Size = new System.Drawing.Size(224, 132);
+            this.kryptonListView3.Size = new System.Drawing.Size(168, 107);
             this.kryptonListView3.TabIndex = 1;
             // 
             // kryptonListBox3
@@ -1320,24 +1292,23 @@ namespace PaletteDesigner
             "List 1",
             "List 2",
             "List 3"});
-            this.kryptonListBox3.Location = new System.Drawing.Point(21, 7);
-            this.kryptonListBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListBox3.Location = new System.Drawing.Point(16, 6);
+            this.kryptonListBox3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListBox3.Name = "kryptonListBox3";
             this.kryptonListBox3.ScrollAlwaysVisible = true;
-            this.kryptonListBox3.Size = new System.Drawing.Size(131, 135);
+            this.kryptonListBox3.Size = new System.Drawing.Size(98, 110);
             this.kryptonListBox3.TabIndex = 0;
             // 
             // kryptonGroupBox2
             // 
-            this.kryptonGroupBox2.Location = new System.Drawing.Point(24, 217);
-            this.kryptonGroupBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.kryptonGroupBox2.Name = "kryptonGroupBox2";
+            this.kryptonGroupBox2.Location = new System.Drawing.Point(18, 176);
+            this.kryptonGroupBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             // 
             // kryptonGroupBox2.Panel
             // 
             this.kryptonGroupBox2.Panel.Controls.Add(this.kryptonListView2);
             this.kryptonGroupBox2.Panel.Controls.Add(this.kryptonListBox2);
-            this.kryptonGroupBox2.Size = new System.Drawing.Size(801, 199);
+            this.kryptonGroupBox2.Size = new System.Drawing.Size(601, 162);
             this.kryptonGroupBox2.TabIndex = 1;
             this.kryptonGroupBox2.Values.Heading = "Enabled";
             // 
@@ -1352,11 +1323,11 @@ namespace PaletteDesigner
             this.kryptonListView2.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem3,
             listViewItem4});
-            this.kryptonListView2.Location = new System.Drawing.Point(212, 14);
-            this.kryptonListView2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListView2.Location = new System.Drawing.Point(159, 11);
+            this.kryptonListView2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListView2.Name = "kryptonListView2";
             this.kryptonListView2.PaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonListView2.Size = new System.Drawing.Size(224, 132);
+            this.kryptonListView2.Size = new System.Drawing.Size(168, 107);
             this.kryptonListView2.TabIndex = 1;
             // 
             // kryptonListBox2
@@ -1372,25 +1343,24 @@ namespace PaletteDesigner
             "List 1",
             "List 2",
             "List 3"});
-            this.kryptonListBox2.Location = new System.Drawing.Point(21, 7);
-            this.kryptonListBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListBox2.Location = new System.Drawing.Point(16, 6);
+            this.kryptonListBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListBox2.Name = "kryptonListBox2";
             this.kryptonListBox2.ScrollAlwaysVisible = true;
-            this.kryptonListBox2.Size = new System.Drawing.Size(131, 135);
+            this.kryptonListBox2.Size = new System.Drawing.Size(98, 110);
             this.kryptonListBox2.TabIndex = 0;
             // 
             // kryptonGroupBox1
             // 
             this.kryptonGroupBox1.Enabled = false;
-            this.kryptonGroupBox1.Location = new System.Drawing.Point(21, 2);
-            this.kryptonGroupBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.kryptonGroupBox1.Name = "kryptonGroupBox1";
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(16, 2);
+            this.kryptonGroupBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             // 
             // kryptonGroupBox1.Panel
             // 
             this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonListView1);
             this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonListBox1);
-            this.kryptonGroupBox1.Size = new System.Drawing.Size(801, 206);
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(601, 167);
             this.kryptonGroupBox1.TabIndex = 0;
             this.kryptonGroupBox1.Values.Heading = "Disabled";
             // 
@@ -1409,11 +1379,11 @@ namespace PaletteDesigner
             this.kryptonListView1.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem5,
             listViewItem6});
-            this.kryptonListView1.Location = new System.Drawing.Point(212, 14);
-            this.kryptonListView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListView1.Location = new System.Drawing.Point(159, 11);
+            this.kryptonListView1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListView1.Name = "kryptonListView1";
             this.kryptonListView1.PaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonListView1.Size = new System.Drawing.Size(224, 132);
+            this.kryptonListView1.Size = new System.Drawing.Size(168, 107);
             this.kryptonListView1.TabIndex = 1;
             // 
             // kryptonListBox1
@@ -1429,11 +1399,11 @@ namespace PaletteDesigner
             "List 1",
             "List 2",
             "List 3"});
-            this.kryptonListBox1.Location = new System.Drawing.Point(21, 7);
-            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonListBox1.Location = new System.Drawing.Point(16, 6);
+            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.kryptonListBox1.Name = "kryptonListBox1";
             this.kryptonListBox1.ScrollAlwaysVisible = true;
-            this.kryptonListBox1.Size = new System.Drawing.Size(131, 135);
+            this.kryptonListBox1.Size = new System.Drawing.Size(98, 110);
             this.kryptonListBox1.TabIndex = 0;
             // 
             // pageDesignControls
@@ -1450,10 +1420,9 @@ namespace PaletteDesigner
             this.pageDesignControls.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignControls.ImageMedium")));
             this.pageDesignControls.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignControls.ImageSmall")));
             this.pageDesignControls.LastVisibleSet = true;
-            this.pageDesignControls.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignControls.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignControls.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignControls.Name = "pageDesignControls";
-            this.pageDesignControls.Size = new System.Drawing.Size(859, 670);
+            this.pageDesignControls.Size = new System.Drawing.Size(644, 544);
             this.pageDesignControls.Text = "Design Controls";
             this.pageDesignControls.TextDescription = "Client is the main style for the client area of Krypton controls.";
             this.pageDesignControls.TextTitle = "Client";
@@ -1466,10 +1435,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelControlsNormal.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelControlsNormal.Location = new System.Drawing.Point(377, 37);
-            this.labelControlsNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.labelControlsNormal.Location = new System.Drawing.Point(283, 30);
             this.labelControlsNormal.Name = "labelControlsNormal";
-            this.labelControlsNormal.Size = new System.Drawing.Size(96, 35);
+            this.labelControlsNormal.Size = new System.Drawing.Size(78, 29);
             this.labelControlsNormal.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelControlsNormal.TabIndex = 0;
             this.labelControlsNormal.Values.Text = "Normal";
@@ -1480,38 +1448,32 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelControlsDisabled.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelControlsDisabled.Location = new System.Drawing.Point(159, 37);
-            this.labelControlsDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.labelControlsDisabled.Location = new System.Drawing.Point(119, 30);
             this.labelControlsDisabled.Name = "labelControlsDisabled";
-            this.labelControlsDisabled.Size = new System.Drawing.Size(108, 35);
+            this.labelControlsDisabled.Size = new System.Drawing.Size(88, 29);
             this.labelControlsDisabled.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelControlsDisabled.TabIndex = 1;
             this.labelControlsDisabled.Values.Text = "Disabled";
             // 
             // control1Normal
             // 
-            this.control1Normal.Location = new System.Drawing.Point(377, 76);
-            this.control1Normal.Margin = new System.Windows.Forms.Padding(4);
-            this.control1Normal.Name = "control1Normal";
-            this.control1Normal.Size = new System.Drawing.Size(133, 123);
+            this.control1Normal.Location = new System.Drawing.Point(283, 62);
+            this.control1Normal.Size = new System.Drawing.Size(100, 100);
             this.control1Normal.TabIndex = 17;
             // 
             // control1Disabled
             // 
-            this.control1Disabled.Location = new System.Drawing.Point(159, 76);
-            this.control1Disabled.Margin = new System.Windows.Forms.Padding(4);
-            this.control1Disabled.Name = "control1Disabled";
-            this.control1Disabled.Size = new System.Drawing.Size(133, 123);
+            this.control1Disabled.Location = new System.Drawing.Point(119, 62);
+            this.control1Disabled.Size = new System.Drawing.Size(100, 100);
             this.control1Disabled.TabIndex = 16;
             // 
             // borderDesignControls
             // 
             this.borderDesignControls.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignControls.Location = new System.Drawing.Point(87, 0);
-            this.borderDesignControls.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignControls.Location = new System.Drawing.Point(73, 0);
             this.borderDesignControls.Name = "borderDesignControls";
             this.borderDesignControls.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignControls.Size = new System.Drawing.Size(1, 670);
+            this.borderDesignControls.Size = new System.Drawing.Size(1, 544);
             this.borderDesignControls.TabIndex = 2;
             // 
             // kryptonNavigatorDesignControls
@@ -1544,8 +1506,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignControls.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignControls.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignControls.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignControls.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignControls.Name = "kryptonNavigatorDesignControls";
             this.kryptonNavigatorDesignControls.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignControls.Owner = null;
             this.kryptonNavigatorDesignControls.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -1558,7 +1518,7 @@ namespace PaletteDesigner
             this.pageControlsCustom1});
             this.kryptonNavigatorDesignControls.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignControls.SelectedIndex = 0;
-            this.kryptonNavigatorDesignControls.Size = new System.Drawing.Size(87, 670);
+            this.kryptonNavigatorDesignControls.Size = new System.Drawing.Size(73, 544);
             this.kryptonNavigatorDesignControls.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignControls.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignControls.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -1575,10 +1535,9 @@ namespace PaletteDesigner
             this.pageControlsClient.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsClient.ImageLarge")));
             this.pageControlsClient.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsClient.ImageMedium")));
             this.pageControlsClient.LastVisibleSet = true;
-            this.pageControlsClient.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsClient.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsClient.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsClient.Name = "pageControlsClient";
-            this.pageControlsClient.Size = new System.Drawing.Size(67, 615);
+            this.pageControlsClient.Size = new System.Drawing.Size(50, 500);
             this.pageControlsClient.Text = "Client";
             this.pageControlsClient.TextDescription = "Client is the main style for the client area of Krypton controls.";
             this.pageControlsClient.ToolTipTitle = "Page ToolTip";
@@ -1591,10 +1550,9 @@ namespace PaletteDesigner
             this.pageControlsAlternate.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsAlternate.ImageLarge")));
             this.pageControlsAlternate.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsAlternate.ImageMedium")));
             this.pageControlsAlternate.LastVisibleSet = true;
-            this.pageControlsAlternate.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsAlternate.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsAlternate.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsAlternate.Name = "pageControlsAlternate";
-            this.pageControlsAlternate.Size = new System.Drawing.Size(67, 615);
+            this.pageControlsAlternate.Size = new System.Drawing.Size(50, 500);
             this.pageControlsAlternate.Text = "Alternate";
             this.pageControlsAlternate.TextDescription = "Alternate provides a complementary variation on the Client style.";
             this.pageControlsAlternate.ToolTipTitle = "Page ToolTip";
@@ -1605,10 +1563,9 @@ namespace PaletteDesigner
             this.pageControlsGroupBox.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageControlsGroupBox.Flags = 65534;
             this.pageControlsGroupBox.LastVisibleSet = true;
-            this.pageControlsGroupBox.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsGroupBox.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsGroupBox.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsGroupBox.Name = "pageControlsGroupBox";
-            this.pageControlsGroupBox.Size = new System.Drawing.Size(133, 123);
+            this.pageControlsGroupBox.Size = new System.Drawing.Size(100, 100);
             this.pageControlsGroupBox.Text = "GroupBox";
             this.pageControlsGroupBox.TextDescription = "GroupBox is applied as the default for KryptonGroupBox instances.";
             this.pageControlsGroupBox.ToolTipTitle = "Page ToolTip";
@@ -1619,10 +1576,9 @@ namespace PaletteDesigner
             this.pageControlsToolTip.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageControlsToolTip.Flags = 65535;
             this.pageControlsToolTip.LastVisibleSet = true;
-            this.pageControlsToolTip.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsToolTip.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsToolTip.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsToolTip.Name = "pageControlsToolTip";
-            this.pageControlsToolTip.Size = new System.Drawing.Size(133, 123);
+            this.pageControlsToolTip.Size = new System.Drawing.Size(100, 100);
             this.pageControlsToolTip.Text = "ToolTip";
             this.pageControlsToolTip.TextDescription = "ToolTip is used for popup windows showing additional context information.";
             this.pageControlsToolTip.ToolTipTitle = "Page ToolTip";
@@ -1633,10 +1589,9 @@ namespace PaletteDesigner
             this.pageControlsRibbon.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageControlsRibbon.Flags = 65535;
             this.pageControlsRibbon.LastVisibleSet = true;
-            this.pageControlsRibbon.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsRibbon.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsRibbon.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsRibbon.Name = "pageControlsRibbon";
-            this.pageControlsRibbon.Size = new System.Drawing.Size(133, 123);
+            this.pageControlsRibbon.Size = new System.Drawing.Size(100, 100);
             this.pageControlsRibbon.Text = "Ribbon";
             this.pageControlsRibbon.TextDescription = "Ribbon is used to achieve a compatible appearance to that of the Ribbon.";
             this.pageControlsRibbon.ToolTipTitle = "Page ToolTip";
@@ -1649,10 +1604,9 @@ namespace PaletteDesigner
             this.pageControlsCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsCustom1.ImageLarge")));
             this.pageControlsCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageControlsCustom1.ImageMedium")));
             this.pageControlsCustom1.LastVisibleSet = true;
-            this.pageControlsCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pageControlsCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageControlsCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageControlsCustom1.Name = "pageControlsCustom1";
-            this.pageControlsCustom1.Size = new System.Drawing.Size(67, 615);
+            this.pageControlsCustom1.Size = new System.Drawing.Size(50, 500);
             this.pageControlsCustom1.Text = "Custom 1";
             this.pageControlsCustom1.TextDescription = "Custom 1 style inherits from Client and is intended for your own custom use.";
             this.pageControlsCustom1.ToolTipTitle = "Page ToolTip";
@@ -1665,10 +1619,9 @@ namespace PaletteDesigner
             this.pageDesignInputControls.Flags = 65535;
             this.pageDesignInputControls.ImageSmall = global::PaletteDesigner.Properties.Resources.KTextBox;
             this.pageDesignInputControls.LastVisibleSet = true;
-            this.pageDesignInputControls.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignInputControls.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignInputControls.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignInputControls.Name = "pageDesignInputControls";
-            this.pageDesignInputControls.Size = new System.Drawing.Size(859, 670);
+            this.pageDesignInputControls.Size = new System.Drawing.Size(644, 544);
             this.pageDesignInputControls.Text = "Design Input Controls";
             this.pageDesignInputControls.TextDescription = "Standalone is appropriate for input controls on a main form.";
             this.pageDesignInputControls.TextTitle = "Standalone";
@@ -1679,9 +1632,9 @@ namespace PaletteDesigner
             // 
             this.inputControls1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.inputControls1.Location = new System.Drawing.Point(0, 0);
-            this.inputControls1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.inputControls1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.inputControls1.Name = "inputControls1";
-            this.inputControls1.Size = new System.Drawing.Size(859, 670);
+            this.inputControls1.Size = new System.Drawing.Size(644, 544);
             this.inputControls1.TabIndex = 0;
             // 
             // pageDesignButtonSpecs
@@ -1702,10 +1655,9 @@ namespace PaletteDesigner
             this.pageDesignButtonSpecs.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignButtonSpecs.ImageMedium")));
             this.pageDesignButtonSpecs.ImageSmall = global::PaletteDesigner.Properties.Resources.KryptonBSActual;
             this.pageDesignButtonSpecs.LastVisibleSet = true;
-            this.pageDesignButtonSpecs.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignButtonSpecs.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignButtonSpecs.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignButtonSpecs.Name = "pageDesignButtonSpecs";
-            this.pageDesignButtonSpecs.Size = new System.Drawing.Size(859, 670);
+            this.pageDesignButtonSpecs.Size = new System.Drawing.Size(644, 544);
             this.pageDesignButtonSpecs.StateCommon.Page.Color1 = System.Drawing.Color.Red;
             this.pageDesignButtonSpecs.Text = "Design ButtonSpecs";
             this.pageDesignButtonSpecs.TextDescription = "Design appearnce of typed and generic button specifications.";
@@ -1720,10 +1672,9 @@ namespace PaletteDesigner
             this.buttonSpecG4.ButtonSpecs.Add(this.buttonSpecGeneric2);
             this.buttonSpecG4.Enabled = false;
             this.buttonSpecG4.HeaderStyle = Krypton.Toolkit.HeaderStyle.Secondary;
-            this.buttonSpecG4.Location = new System.Drawing.Point(24, 501);
-            this.buttonSpecG4.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecG4.Location = new System.Drawing.Point(18, 407);
             this.buttonSpecG4.Name = "buttonSpecG4";
-            this.buttonSpecG4.Size = new System.Drawing.Size(351, 34);
+            this.buttonSpecG4.Size = new System.Drawing.Size(263, 28);
             this.buttonSpecG4.TabIndex = 28;
             this.buttonSpecG4.Values.Description = "";
             this.buttonSpecG4.Values.Heading = "Disabled";
@@ -1745,10 +1696,9 @@ namespace PaletteDesigner
             this.buttonSpecG3.ButtonSpecs.Add(this.buttonSpecGeneric1);
             this.buttonSpecG3.ButtonSpecs.Add(this.buttonSpecGeneric2);
             this.buttonSpecG3.Enabled = false;
-            this.buttonSpecG3.Location = new System.Drawing.Point(24, 446);
-            this.buttonSpecG3.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecG3.Location = new System.Drawing.Point(18, 362);
             this.buttonSpecG3.Name = "buttonSpecG3";
-            this.buttonSpecG3.Size = new System.Drawing.Size(351, 46);
+            this.buttonSpecG3.Size = new System.Drawing.Size(263, 37);
             this.buttonSpecG3.TabIndex = 27;
             this.buttonSpecG3.Values.Description = "";
             this.buttonSpecG3.Values.Heading = "Disabled";
@@ -1760,10 +1710,9 @@ namespace PaletteDesigner
             this.buttonSpecG2.ButtonSpecs.Add(this.buttonSpecGeneric1);
             this.buttonSpecG2.ButtonSpecs.Add(this.buttonSpecGeneric2);
             this.buttonSpecG2.HeaderStyle = Krypton.Toolkit.HeaderStyle.Secondary;
-            this.buttonSpecG2.Location = new System.Drawing.Point(24, 393);
-            this.buttonSpecG2.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecG2.Location = new System.Drawing.Point(18, 319);
             this.buttonSpecG2.Name = "buttonSpecG2";
-            this.buttonSpecG2.Size = new System.Drawing.Size(351, 34);
+            this.buttonSpecG2.Size = new System.Drawing.Size(263, 28);
             this.buttonSpecG2.TabIndex = 26;
             this.buttonSpecG2.Values.Description = "";
             this.buttonSpecG2.Values.Heading = "Header2";
@@ -1774,10 +1723,9 @@ namespace PaletteDesigner
             this.buttonSpecG1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.buttonSpecG1.ButtonSpecs.Add(this.buttonSpecGeneric1);
             this.buttonSpecG1.ButtonSpecs.Add(this.buttonSpecGeneric2);
-            this.buttonSpecG1.Location = new System.Drawing.Point(24, 338);
-            this.buttonSpecG1.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecG1.Location = new System.Drawing.Point(18, 275);
             this.buttonSpecG1.Name = "buttonSpecG1";
-            this.buttonSpecG1.Size = new System.Drawing.Size(351, 46);
+            this.buttonSpecG1.Size = new System.Drawing.Size(263, 37);
             this.buttonSpecG1.TabIndex = 25;
             this.buttonSpecG1.Values.Description = "";
             this.buttonSpecG1.Values.Heading = "Header1";
@@ -1804,10 +1752,9 @@ namespace PaletteDesigner
             this.buttonSpecT4.ButtonSpecs.Add(this.buttonSpecAny56);
             this.buttonSpecT4.Enabled = false;
             this.buttonSpecT4.HeaderStyle = Krypton.Toolkit.HeaderStyle.Secondary;
-            this.buttonSpecT4.Location = new System.Drawing.Point(24, 230);
-            this.buttonSpecT4.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecT4.Location = new System.Drawing.Point(18, 187);
             this.buttonSpecT4.Name = "buttonSpecT4";
-            this.buttonSpecT4.Size = new System.Drawing.Size(580, 44);
+            this.buttonSpecT4.Size = new System.Drawing.Size(435, 36);
             this.buttonSpecT4.TabIndex = 24;
             this.buttonSpecT4.Values.Description = "";
             this.buttonSpecT4.Values.Heading = "Disabled";
@@ -1913,10 +1860,9 @@ namespace PaletteDesigner
             this.buttonSpecT3.ButtonSpecs.Add(this.buttonSpecAny53);
             this.buttonSpecT3.ButtonSpecs.Add(this.buttonSpecAny54);
             this.buttonSpecT3.Enabled = false;
-            this.buttonSpecT3.Location = new System.Drawing.Point(24, 176);
-            this.buttonSpecT3.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecT3.Location = new System.Drawing.Point(18, 143);
             this.buttonSpecT3.Name = "buttonSpecT3";
-            this.buttonSpecT3.Size = new System.Drawing.Size(631, 46);
+            this.buttonSpecT3.Size = new System.Drawing.Size(473, 37);
             this.buttonSpecT3.TabIndex = 23;
             this.buttonSpecT3.Values.Description = "";
             this.buttonSpecT3.Values.Heading = "Disabled";
@@ -2022,10 +1968,9 @@ namespace PaletteDesigner
             this.buttonSpecT2.ButtonSpecs.Add(this.buttonSpecAny47);
             this.buttonSpecT2.ButtonSpecs.Add(this.buttonSpecAny52);
             this.buttonSpecT2.HeaderStyle = Krypton.Toolkit.HeaderStyle.Secondary;
-            this.buttonSpecT2.Location = new System.Drawing.Point(24, 122);
-            this.buttonSpecT2.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecT2.Location = new System.Drawing.Point(18, 99);
             this.buttonSpecT2.Name = "buttonSpecT2";
-            this.buttonSpecT2.Size = new System.Drawing.Size(579, 44);
+            this.buttonSpecT2.Size = new System.Drawing.Size(434, 36);
             this.buttonSpecT2.TabIndex = 22;
             this.buttonSpecT2.Values.Description = "";
             this.buttonSpecT2.Values.Heading = "Header2";
@@ -2130,10 +2075,9 @@ namespace PaletteDesigner
             this.buttonSpecT1.ButtonSpecs.Add(this.buttonSpecAny37);
             this.buttonSpecT1.ButtonSpecs.Add(this.buttonSpecAny46);
             this.buttonSpecT1.ButtonSpecs.Add(this.buttonSpecAny45);
-            this.buttonSpecT1.Location = new System.Drawing.Point(24, 68);
-            this.buttonSpecT1.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonSpecT1.Location = new System.Drawing.Point(18, 55);
             this.buttonSpecT1.Name = "buttonSpecT1";
-            this.buttonSpecT1.Size = new System.Drawing.Size(628, 46);
+            this.buttonSpecT1.Size = new System.Drawing.Size(471, 37);
             this.buttonSpecT1.TabIndex = 21;
             this.buttonSpecT1.Values.Description = "";
             this.buttonSpecT1.Values.Heading = "Header1";
@@ -2222,20 +2166,18 @@ namespace PaletteDesigner
             // labelButtonSpecsTyped
             // 
             this.labelButtonSpecsTyped.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelButtonSpecsTyped.Location = new System.Drawing.Point(24, 30);
-            this.labelButtonSpecsTyped.Margin = new System.Windows.Forms.Padding(4);
+            this.labelButtonSpecsTyped.Location = new System.Drawing.Point(18, 24);
             this.labelButtonSpecsTyped.Name = "labelButtonSpecsTyped";
-            this.labelButtonSpecsTyped.Size = new System.Drawing.Size(214, 35);
+            this.labelButtonSpecsTyped.Size = new System.Drawing.Size(172, 29);
             this.labelButtonSpecsTyped.TabIndex = 29;
             this.labelButtonSpecsTyped.Values.Text = "Typed ButtonSpec";
             // 
             // labelButtonSpecsGeneric
             // 
             this.labelButtonSpecsGeneric.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelButtonSpecsGeneric.Location = new System.Drawing.Point(24, 300);
-            this.labelButtonSpecsGeneric.Margin = new System.Windows.Forms.Padding(4);
+            this.labelButtonSpecsGeneric.Location = new System.Drawing.Point(18, 244);
             this.labelButtonSpecsGeneric.Name = "labelButtonSpecsGeneric";
-            this.labelButtonSpecsGeneric.Size = new System.Drawing.Size(229, 35);
+            this.labelButtonSpecsGeneric.Size = new System.Drawing.Size(184, 29);
             this.labelButtonSpecsGeneric.TabIndex = 30;
             this.labelButtonSpecsGeneric.Values.Text = "Generic ButtonSpec";
             // 
@@ -2248,10 +2190,9 @@ namespace PaletteDesigner
             this.pageDesignButtons.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignButtons.ImageMedium")));
             this.pageDesignButtons.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignButtons.ImageSmall")));
             this.pageDesignButtons.LastVisibleSet = true;
-            this.pageDesignButtons.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignButtons.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignButtons.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignButtons.Name = "pageDesignButtons";
-            this.pageDesignButtons.Size = new System.Drawing.Size(857, 672);
+            this.pageDesignButtons.Size = new System.Drawing.Size(643, 546);
             this.pageDesignButtons.Text = "Design Buttons";
             this.pageDesignButtons.TextDescription = "Standalone is the main button style and intended for individual button instances." +
     "";
@@ -2262,8 +2203,9 @@ namespace PaletteDesigner
             // buttonsPage1
             // 
             this.buttonsPage1.Location = new System.Drawing.Point(0, 0);
+            this.buttonsPage1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.buttonsPage1.Name = "buttonsPage1";
-            this.buttonsPage1.Size = new System.Drawing.Size(867, 670);
+            this.buttonsPage1.Size = new System.Drawing.Size(650, 544);
             this.buttonsPage1.TabIndex = 0;
             // 
             // pageDesignCheckBox
@@ -2287,11 +2229,10 @@ namespace PaletteDesigner
             this.pageDesignCheckBox.Flags = 65535;
             this.pageDesignCheckBox.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignCheckBox.ImageSmall")));
             this.pageDesignCheckBox.LastVisibleSet = true;
-            this.pageDesignCheckBox.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignCheckBox.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignCheckBox.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignCheckBox.Name = "pageDesignCheckBox";
-            this.pageDesignCheckBox.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
-            this.pageDesignCheckBox.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignCheckBox.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.pageDesignCheckBox.Size = new System.Drawing.Size(462, 524);
             this.pageDesignCheckBox.Text = "Design CheckBox";
             this.pageDesignCheckBox.TextDescription = "Preview appearance of the CheckBox control.";
             this.pageDesignCheckBox.TextTitle = "";
@@ -2302,20 +2243,18 @@ namespace PaletteDesigner
             // 
             this.cbLive.Checked = true;
             this.cbLive.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbLive.Location = new System.Drawing.Point(273, 281);
-            this.cbLive.Margin = new System.Windows.Forms.Padding(4);
+            this.cbLive.Location = new System.Drawing.Point(205, 228);
             this.cbLive.Name = "cbLive";
-            this.cbLive.Size = new System.Drawing.Size(51, 24);
+            this.cbLive.Size = new System.Drawing.Size(45, 20);
             this.cbLive.TabIndex = 14;
             this.cbLive.ThreeState = true;
             this.cbLive.Values.Text = "Live";
             // 
             // cbFocus
             // 
-            this.cbFocus.Location = new System.Drawing.Point(273, 234);
-            this.cbFocus.Margin = new System.Windows.Forms.Padding(4);
+            this.cbFocus.Location = new System.Drawing.Point(205, 190);
             this.cbFocus.Name = "cbFocus";
-            this.cbFocus.Size = new System.Drawing.Size(64, 24);
+            this.cbFocus.Size = new System.Drawing.Size(55, 20);
             this.cbFocus.TabIndex = 13;
             this.cbFocus.Values.Text = "Focus";
             // 
@@ -2323,10 +2262,9 @@ namespace PaletteDesigner
             // 
             this.cbIndeterminateTracking.Checked = true;
             this.cbIndeterminateTracking.CheckState = System.Windows.Forms.CheckState.Indeterminate;
-            this.cbIndeterminateTracking.Location = new System.Drawing.Point(31, 327);
-            this.cbIndeterminateTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.cbIndeterminateTracking.Location = new System.Drawing.Point(23, 266);
             this.cbIndeterminateTracking.Name = "cbIndeterminateTracking";
-            this.cbIndeterminateTracking.Size = new System.Drawing.Size(182, 24);
+            this.cbIndeterminateTracking.Size = new System.Drawing.Size(150, 20);
             this.cbIndeterminateTracking.TabIndex = 12;
             this.cbIndeterminateTracking.Values.Text = "Indeterminate Tracking";
             // 
@@ -2334,10 +2272,9 @@ namespace PaletteDesigner
             // 
             this.cbIndeterminatePressed.Checked = true;
             this.cbIndeterminatePressed.CheckState = System.Windows.Forms.CheckState.Indeterminate;
-            this.cbIndeterminatePressed.Location = new System.Drawing.Point(31, 374);
-            this.cbIndeterminatePressed.Margin = new System.Windows.Forms.Padding(4);
+            this.cbIndeterminatePressed.Location = new System.Drawing.Point(23, 304);
             this.cbIndeterminatePressed.Name = "cbIndeterminatePressed";
-            this.cbIndeterminatePressed.Size = new System.Drawing.Size(177, 24);
+            this.cbIndeterminatePressed.Size = new System.Drawing.Size(145, 20);
             this.cbIndeterminatePressed.TabIndex = 11;
             this.cbIndeterminatePressed.Values.Text = "Indeterminate Pressed";
             // 
@@ -2345,10 +2282,9 @@ namespace PaletteDesigner
             // 
             this.cbIndeterminateNormal.Checked = true;
             this.cbIndeterminateNormal.CheckState = System.Windows.Forms.CheckState.Indeterminate;
-            this.cbIndeterminateNormal.Location = new System.Drawing.Point(31, 281);
-            this.cbIndeterminateNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.cbIndeterminateNormal.Location = new System.Drawing.Point(23, 228);
             this.cbIndeterminateNormal.Name = "cbIndeterminateNormal";
-            this.cbIndeterminateNormal.Size = new System.Drawing.Size(175, 24);
+            this.cbIndeterminateNormal.Size = new System.Drawing.Size(144, 20);
             this.cbIndeterminateNormal.TabIndex = 10;
             this.cbIndeterminateNormal.Values.Text = "Indeterminate Normal";
             // 
@@ -2356,10 +2292,9 @@ namespace PaletteDesigner
             // 
             this.cbIndeterminateDisabled.Checked = true;
             this.cbIndeterminateDisabled.CheckState = System.Windows.Forms.CheckState.Indeterminate;
-            this.cbIndeterminateDisabled.Location = new System.Drawing.Point(31, 234);
-            this.cbIndeterminateDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.cbIndeterminateDisabled.Location = new System.Drawing.Point(23, 190);
             this.cbIndeterminateDisabled.Name = "cbIndeterminateDisabled";
-            this.cbIndeterminateDisabled.Size = new System.Drawing.Size(183, 24);
+            this.cbIndeterminateDisabled.Size = new System.Drawing.Size(151, 20);
             this.cbIndeterminateDisabled.TabIndex = 9;
             this.cbIndeterminateDisabled.Values.Text = "Indeterminate Disabled";
             // 
@@ -2367,10 +2302,9 @@ namespace PaletteDesigner
             // 
             this.cbCheckedTracking.Checked = true;
             this.cbCheckedTracking.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbCheckedTracking.Location = new System.Drawing.Point(273, 122);
-            this.cbCheckedTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.cbCheckedTracking.Location = new System.Drawing.Point(205, 99);
             this.cbCheckedTracking.Name = "cbCheckedTracking";
-            this.cbCheckedTracking.Size = new System.Drawing.Size(145, 24);
+            this.cbCheckedTracking.Size = new System.Drawing.Size(120, 20);
             this.cbCheckedTracking.TabIndex = 8;
             this.cbCheckedTracking.Values.Text = "Checked Tracking";
             // 
@@ -2378,10 +2312,9 @@ namespace PaletteDesigner
             // 
             this.cbCheckedPressed.Checked = true;
             this.cbCheckedPressed.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbCheckedPressed.Location = new System.Drawing.Point(273, 169);
-            this.cbCheckedPressed.Margin = new System.Windows.Forms.Padding(4);
+            this.cbCheckedPressed.Location = new System.Drawing.Point(205, 137);
             this.cbCheckedPressed.Name = "cbCheckedPressed";
-            this.cbCheckedPressed.Size = new System.Drawing.Size(139, 24);
+            this.cbCheckedPressed.Size = new System.Drawing.Size(115, 20);
             this.cbCheckedPressed.TabIndex = 7;
             this.cbCheckedPressed.Values.Text = "Checked Pressed";
             // 
@@ -2389,10 +2322,9 @@ namespace PaletteDesigner
             // 
             this.cbCheckedNormal.Checked = true;
             this.cbCheckedNormal.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbCheckedNormal.Location = new System.Drawing.Point(273, 75);
-            this.cbCheckedNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.cbCheckedNormal.Location = new System.Drawing.Point(205, 61);
             this.cbCheckedNormal.Name = "cbCheckedNormal";
-            this.cbCheckedNormal.Size = new System.Drawing.Size(138, 24);
+            this.cbCheckedNormal.Size = new System.Drawing.Size(114, 20);
             this.cbCheckedNormal.TabIndex = 6;
             this.cbCheckedNormal.Values.Text = "Checked Normal";
             // 
@@ -2400,55 +2332,49 @@ namespace PaletteDesigner
             // 
             this.cbCheckedDisabled.Checked = true;
             this.cbCheckedDisabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbCheckedDisabled.Location = new System.Drawing.Point(273, 28);
-            this.cbCheckedDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.cbCheckedDisabled.Location = new System.Drawing.Point(205, 23);
             this.cbCheckedDisabled.Name = "cbCheckedDisabled";
-            this.cbCheckedDisabled.Size = new System.Drawing.Size(146, 24);
+            this.cbCheckedDisabled.Size = new System.Drawing.Size(121, 20);
             this.cbCheckedDisabled.TabIndex = 5;
             this.cbCheckedDisabled.Values.Text = "Checked Disabled";
             // 
             // cbUncheckedTracking
             // 
-            this.cbUncheckedTracking.Location = new System.Drawing.Point(31, 122);
-            this.cbUncheckedTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.cbUncheckedTracking.Location = new System.Drawing.Point(23, 99);
             this.cbUncheckedTracking.Name = "cbUncheckedTracking";
-            this.cbUncheckedTracking.Size = new System.Drawing.Size(162, 24);
+            this.cbUncheckedTracking.Size = new System.Drawing.Size(133, 20);
             this.cbUncheckedTracking.TabIndex = 4;
             this.cbUncheckedTracking.Values.Text = "Unchecked Tracking";
             // 
             // cbUncheckedPressed
             // 
-            this.cbUncheckedPressed.Location = new System.Drawing.Point(31, 169);
-            this.cbUncheckedPressed.Margin = new System.Windows.Forms.Padding(4);
+            this.cbUncheckedPressed.Location = new System.Drawing.Point(23, 137);
             this.cbUncheckedPressed.Name = "cbUncheckedPressed";
-            this.cbUncheckedPressed.Size = new System.Drawing.Size(156, 24);
+            this.cbUncheckedPressed.Size = new System.Drawing.Size(129, 20);
             this.cbUncheckedPressed.TabIndex = 3;
             this.cbUncheckedPressed.Values.Text = "Unchecked Pressed";
             // 
             // cbUncheckedNormal
             // 
-            this.cbUncheckedNormal.Location = new System.Drawing.Point(31, 75);
-            this.cbUncheckedNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.cbUncheckedNormal.Location = new System.Drawing.Point(23, 61);
             this.cbUncheckedNormal.Name = "cbUncheckedNormal";
-            this.cbUncheckedNormal.Size = new System.Drawing.Size(155, 24);
+            this.cbUncheckedNormal.Size = new System.Drawing.Size(128, 20);
             this.cbUncheckedNormal.TabIndex = 2;
             this.cbUncheckedNormal.Values.Text = "Unchecked Normal";
             // 
             // cbUncheckedDisabled
             // 
-            this.cbUncheckedDisabled.Location = new System.Drawing.Point(31, 28);
-            this.cbUncheckedDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.cbUncheckedDisabled.Location = new System.Drawing.Point(23, 23);
             this.cbUncheckedDisabled.Name = "cbUncheckedDisabled";
-            this.cbUncheckedDisabled.Size = new System.Drawing.Size(163, 24);
+            this.cbUncheckedDisabled.Size = new System.Drawing.Size(134, 20);
             this.cbUncheckedDisabled.TabIndex = 1;
             this.cbUncheckedDisabled.Values.Text = "Unchecked Disabled";
             // 
             // kryptonCheckBox1
             // 
-            this.kryptonCheckBox1.Location = new System.Drawing.Point(1173, 36);
-            this.kryptonCheckBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonCheckBox1.Location = new System.Drawing.Point(880, 29);
             this.kryptonCheckBox1.Name = "kryptonCheckBox1";
-            this.kryptonCheckBox1.Size = new System.Drawing.Size(163, 24);
+            this.kryptonCheckBox1.Size = new System.Drawing.Size(134, 20);
             this.kryptonCheckBox1.TabIndex = 0;
             this.kryptonCheckBox1.Values.Text = "Unchecked Disabled";
             // 
@@ -2460,11 +2386,10 @@ namespace PaletteDesigner
             this.pageDesignChromeTMS.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignChromeTMS.ImageMedium")));
             this.pageDesignChromeTMS.ImageSmall = global::PaletteDesigner.Properties.Resources.KryptonTMS;
             this.pageDesignChromeTMS.LastVisibleSet = true;
-            this.pageDesignChromeTMS.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignChromeTMS.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignChromeTMS.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignChromeTMS.Name = "pageDesignChromeTMS";
-            this.pageDesignChromeTMS.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
-            this.pageDesignChromeTMS.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignChromeTMS.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.pageDesignChromeTMS.Size = new System.Drawing.Size(462, 524);
             this.pageDesignChromeTMS.Text = "Design Chrome + TMS";
             this.pageDesignChromeTMS.TextDescription = "Preview settings for custom chrome and Tool, Menu, Context and Status strips.";
             this.pageDesignChromeTMS.TextTitle = "";
@@ -2483,10 +2408,9 @@ namespace PaletteDesigner
             this.pageDesignGrid.Flags = 65535;
             this.pageDesignGrid.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignGrid.ImageSmall")));
             this.pageDesignGrid.LastVisibleSet = true;
-            this.pageDesignGrid.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignGrid.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignGrid.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignGrid.Name = "pageDesignGrid";
-            this.pageDesignGrid.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignGrid.Size = new System.Drawing.Size(462, 524);
             this.pageDesignGrid.Text = "Design Grids";
             this.pageDesignGrid.TextDescription = "List is the default grid style.";
             this.pageDesignGrid.TextTitle = "List";
@@ -2499,42 +2423,17 @@ namespace PaletteDesigner
             this.dataGridViewDisabled.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dataGridViewDisabled.ColumnHeadersHeight = 36;
             this.dataGridViewDisabled.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.column1DataGridViewTextBoxColumn1,
-            this.column2DataGridViewTextBoxColumn1,
-            this.column3DataGridViewTextBoxColumn1});
+            this.kryptonDataGridViewTextBoxColumn4,
+            this.kryptonDataGridViewTextBoxColumn5,
+            this.kryptonDataGridViewTextBoxColumn6});
             this.dataGridViewDisabled.DataMember = "Table1";
             this.dataGridViewDisabled.DataSource = this.dataSetGrid;
             this.dataGridViewDisabled.Enabled = false;
-            this.dataGridViewDisabled.Location = new System.Drawing.Point(133, 308);
-            this.dataGridViewDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.dataGridViewDisabled.Location = new System.Drawing.Point(100, 250);
             this.dataGridViewDisabled.Name = "dataGridViewDisabled";
             this.dataGridViewDisabled.RowHeadersWidth = 51;
-            this.dataGridViewDisabled.Size = new System.Drawing.Size(411, 167);
+            this.dataGridViewDisabled.Size = new System.Drawing.Size(308, 136);
             this.dataGridViewDisabled.TabIndex = 21;
-            // 
-            // column1DataGridViewTextBoxColumn1
-            // 
-            this.column1DataGridViewTextBoxColumn1.DataPropertyName = "Column1";
-            this.column1DataGridViewTextBoxColumn1.HeaderText = "Column1";
-            this.column1DataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.column1DataGridViewTextBoxColumn1.Name = "column1DataGridViewTextBoxColumn1";
-            this.column1DataGridViewTextBoxColumn1.Width = 75;
-            // 
-            // column2DataGridViewTextBoxColumn1
-            // 
-            this.column2DataGridViewTextBoxColumn1.DataPropertyName = "Column2";
-            this.column2DataGridViewTextBoxColumn1.HeaderText = "Column2";
-            this.column2DataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.column2DataGridViewTextBoxColumn1.Name = "column2DataGridViewTextBoxColumn1";
-            this.column2DataGridViewTextBoxColumn1.Width = 75;
-            // 
-            // column3DataGridViewTextBoxColumn1
-            // 
-            this.column3DataGridViewTextBoxColumn1.DataPropertyName = "Column3";
-            this.column3DataGridViewTextBoxColumn1.HeaderText = "Column3";
-            this.column3DataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.column3DataGridViewTextBoxColumn1.Name = "column3DataGridViewTextBoxColumn1";
-            this.column3DataGridViewTextBoxColumn1.Width = 75;
             // 
             // dataSetGrid
             // 
@@ -2575,10 +2474,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelGridDisabled.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelGridDisabled.Location = new System.Drawing.Point(133, 270);
-            this.labelGridDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.labelGridDisabled.Location = new System.Drawing.Point(100, 219);
             this.labelGridDisabled.Name = "labelGridDisabled";
-            this.labelGridDisabled.Size = new System.Drawing.Size(108, 35);
+            this.labelGridDisabled.Size = new System.Drawing.Size(88, 29);
             this.labelGridDisabled.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelGridDisabled.TabIndex = 22;
             this.labelGridDisabled.Values.Text = "Disabled";
@@ -2589,10 +2487,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonLabel2.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.kryptonLabel2.Location = new System.Drawing.Point(1332, 494);
-            this.kryptonLabel2.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel2.Location = new System.Drawing.Point(999, 401);
             this.kryptonLabel2.Name = "kryptonLabel2";
-            this.kryptonLabel2.Size = new System.Drawing.Size(96, 35);
+            this.kryptonLabel2.Size = new System.Drawing.Size(78, 29);
             this.kryptonLabel2.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonLabel2.TabIndex = 23;
             this.kryptonLabel2.Values.Text = "Normal";
@@ -2603,10 +2500,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.kryptonLabel1.Location = new System.Drawing.Point(133, 30);
-            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel1.Location = new System.Drawing.Point(100, 24);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(96, 35);
+            this.kryptonLabel1.Size = new System.Drawing.Size(78, 29);
             this.kryptonLabel1.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonLabel1.TabIndex = 24;
             this.kryptonLabel1.Values.Text = "Normal";
@@ -2617,41 +2513,16 @@ namespace PaletteDesigner
             this.dataGridViewNormal.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dataGridViewNormal.ColumnHeadersHeight = 36;
             this.dataGridViewNormal.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.column1DataGridViewTextBoxColumn,
-            this.column2DataGridViewTextBoxColumn,
-            this.column3DataGridViewTextBoxColumn});
+            this.kryptonDataGridViewTextBoxColumn1,
+            this.kryptonDataGridViewTextBoxColumn2,
+            this.kryptonDataGridViewTextBoxColumn3});
             this.dataGridViewNormal.DataMember = "Table1";
             this.dataGridViewNormal.DataSource = this.dataSetGrid;
-            this.dataGridViewNormal.Location = new System.Drawing.Point(133, 68);
-            this.dataGridViewNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.dataGridViewNormal.Location = new System.Drawing.Point(100, 55);
             this.dataGridViewNormal.Name = "dataGridViewNormal";
             this.dataGridViewNormal.RowHeadersWidth = 51;
-            this.dataGridViewNormal.Size = new System.Drawing.Size(411, 167);
+            this.dataGridViewNormal.Size = new System.Drawing.Size(308, 136);
             this.dataGridViewNormal.TabIndex = 2;
-            // 
-            // column1DataGridViewTextBoxColumn
-            // 
-            this.column1DataGridViewTextBoxColumn.DataPropertyName = "Column1";
-            this.column1DataGridViewTextBoxColumn.HeaderText = "Column1";
-            this.column1DataGridViewTextBoxColumn.MinimumWidth = 6;
-            this.column1DataGridViewTextBoxColumn.Name = "column1DataGridViewTextBoxColumn";
-            this.column1DataGridViewTextBoxColumn.Width = 75;
-            // 
-            // column2DataGridViewTextBoxColumn
-            // 
-            this.column2DataGridViewTextBoxColumn.DataPropertyName = "Column2";
-            this.column2DataGridViewTextBoxColumn.HeaderText = "Column2";
-            this.column2DataGridViewTextBoxColumn.MinimumWidth = 6;
-            this.column2DataGridViewTextBoxColumn.Name = "column2DataGridViewTextBoxColumn";
-            this.column2DataGridViewTextBoxColumn.Width = 75;
-            // 
-            // column3DataGridViewTextBoxColumn
-            // 
-            this.column3DataGridViewTextBoxColumn.DataPropertyName = "Column3";
-            this.column3DataGridViewTextBoxColumn.HeaderText = "Column3";
-            this.column3DataGridViewTextBoxColumn.MinimumWidth = 6;
-            this.column3DataGridViewTextBoxColumn.Name = "column3DataGridViewTextBoxColumn";
-            this.column3DataGridViewTextBoxColumn.Width = 75;
             // 
             // kryptonNavigatorDesignGrids
             // 
@@ -2683,8 +2554,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignGrids.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignGrids.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignGrids.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignGrids.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignGrids.Name = "kryptonNavigatorDesignGrids";
             this.kryptonNavigatorDesignGrids.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignGrids.Owner = null;
             this.kryptonNavigatorDesignGrids.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -2694,7 +2563,7 @@ namespace PaletteDesigner
             this.kryptonGridCustom1});
             this.kryptonNavigatorDesignGrids.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignGrids.SelectedIndex = 0;
-            this.kryptonNavigatorDesignGrids.Size = new System.Drawing.Size(85, 645);
+            this.kryptonNavigatorDesignGrids.Size = new System.Drawing.Size(71, 524);
             this.kryptonNavigatorDesignGrids.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignGrids.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignGrids.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -2711,10 +2580,9 @@ namespace PaletteDesigner
             this.kryptonGridList.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridList.ImageLarge")));
             this.kryptonGridList.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridList.ImageMedium")));
             this.kryptonGridList.LastVisibleSet = true;
-            this.kryptonGridList.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGridList.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonGridList.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonGridList.Name = "kryptonGridList";
-            this.kryptonGridList.Size = new System.Drawing.Size(67, 615);
+            this.kryptonGridList.Size = new System.Drawing.Size(50, 500);
             this.kryptonGridList.Text = "List";
             this.kryptonGridList.TextDescription = "List is the default grid style.";
             this.kryptonGridList.ToolTipTitle = "Page ToolTip";
@@ -2727,10 +2595,9 @@ namespace PaletteDesigner
             this.kryptonGridSheet.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridSheet.ImageLarge")));
             this.kryptonGridSheet.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridSheet.ImageMedium")));
             this.kryptonGridSheet.LastVisibleSet = true;
-            this.kryptonGridSheet.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGridSheet.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonGridSheet.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonGridSheet.Name = "kryptonGridSheet";
-            this.kryptonGridSheet.Size = new System.Drawing.Size(67, 615);
+            this.kryptonGridSheet.Size = new System.Drawing.Size(50, 500);
             this.kryptonGridSheet.Text = "Sheet";
             this.kryptonGridSheet.TextDescription = "Sheet is used when a worksheet style is required.";
             this.kryptonGridSheet.ToolTipTitle = "Page ToolTip";
@@ -2743,10 +2610,9 @@ namespace PaletteDesigner
             this.kryptonGridCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridCustom1.ImageLarge")));
             this.kryptonGridCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonGridCustom1.ImageMedium")));
             this.kryptonGridCustom1.LastVisibleSet = true;
-            this.kryptonGridCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGridCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonGridCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonGridCustom1.Name = "kryptonGridCustom1";
-            this.kryptonGridCustom1.Size = new System.Drawing.Size(67, 615);
+            this.kryptonGridCustom1.Size = new System.Drawing.Size(50, 500);
             this.kryptonGridCustom1.Text = "Custom 1";
             this.kryptonGridCustom1.TextDescription = "Custom 1 style inherits from List and is intended for your own custom use.";
             this.kryptonGridCustom1.ToolTipTitle = "Page ToolTip";
@@ -2764,10 +2630,9 @@ namespace PaletteDesigner
             this.pageDesignHeaderGroup.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignHeaderGroup.ImageMedium")));
             this.pageDesignHeaderGroup.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignHeaderGroup.ImageSmall")));
             this.pageDesignHeaderGroup.LastVisibleSet = true;
-            this.pageDesignHeaderGroup.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignHeaderGroup.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignHeaderGroup.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignHeaderGroup.Name = "pageDesignHeaderGroup";
-            this.pageDesignHeaderGroup.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignHeaderGroup.Size = new System.Drawing.Size(462, 524);
             this.pageDesignHeaderGroup.Text = "Design HeaderGroup";
             this.pageDesignHeaderGroup.TextDescription = "Define common properties applied to all HeaderGroups.";
             this.pageDesignHeaderGroup.TextTitle = "";
@@ -2777,40 +2642,34 @@ namespace PaletteDesigner
             // labelHeaderGroupNormal
             // 
             this.labelHeaderGroupNormal.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelHeaderGroupNormal.Location = new System.Drawing.Point(305, 28);
-            this.labelHeaderGroupNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.labelHeaderGroupNormal.Location = new System.Drawing.Point(229, 23);
             this.labelHeaderGroupNormal.Name = "labelHeaderGroupNormal";
-            this.labelHeaderGroupNormal.Size = new System.Drawing.Size(96, 35);
+            this.labelHeaderGroupNormal.Size = new System.Drawing.Size(78, 29);
             this.labelHeaderGroupNormal.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelHeaderGroupNormal.TabIndex = 0;
             this.labelHeaderGroupNormal.Values.Text = "Normal";
             // 
             // headerGroup1Disabled
             // 
-            this.headerGroup1Disabled.Location = new System.Drawing.Point(37, 68);
-            this.headerGroup1Disabled.Margin = new System.Windows.Forms.Padding(4);
-            this.headerGroup1Disabled.Name = "headerGroup1Disabled";
-            this.headerGroup1Disabled.Size = new System.Drawing.Size(211, 185);
+            this.headerGroup1Disabled.Location = new System.Drawing.Point(28, 55);
+            this.headerGroup1Disabled.Size = new System.Drawing.Size(158, 150);
             this.headerGroup1Disabled.TabIndex = 14;
             this.headerGroup1Disabled.ValuesPrimary.Image = ((System.Drawing.Image)(resources.GetObject("headerGroup1Disabled.ValuesPrimary.Image")));
             // 
             // labelHeaderGroupDisabled
             // 
             this.labelHeaderGroupDisabled.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelHeaderGroupDisabled.Location = new System.Drawing.Point(37, 28);
-            this.labelHeaderGroupDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.labelHeaderGroupDisabled.Location = new System.Drawing.Point(28, 23);
             this.labelHeaderGroupDisabled.Name = "labelHeaderGroupDisabled";
-            this.labelHeaderGroupDisabled.Size = new System.Drawing.Size(108, 35);
+            this.labelHeaderGroupDisabled.Size = new System.Drawing.Size(88, 29);
             this.labelHeaderGroupDisabled.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelHeaderGroupDisabled.TabIndex = 15;
             this.labelHeaderGroupDisabled.Values.Text = "Disabled";
             // 
             // headerGroup1Normal
             // 
-            this.headerGroup1Normal.Location = new System.Drawing.Point(305, 68);
-            this.headerGroup1Normal.Margin = new System.Windows.Forms.Padding(4);
-            this.headerGroup1Normal.Name = "headerGroup1Normal";
-            this.headerGroup1Normal.Size = new System.Drawing.Size(211, 185);
+            this.headerGroup1Normal.Location = new System.Drawing.Point(229, 55);
+            this.headerGroup1Normal.Size = new System.Drawing.Size(158, 150);
             this.headerGroup1Normal.TabIndex = 17;
             this.headerGroup1Normal.ValuesPrimary.Image = ((System.Drawing.Image)(resources.GetObject("headerGroup1Normal.ValuesPrimary.Image")));
             // 
@@ -2826,10 +2685,9 @@ namespace PaletteDesigner
             this.pageDesignHeaders.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignHeaders.ImageMedium")));
             this.pageDesignHeaders.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignHeaders.ImageSmall")));
             this.pageDesignHeaders.LastVisibleSet = true;
-            this.pageDesignHeaders.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignHeaders.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignHeaders.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignHeaders.Name = "pageDesignHeaders";
-            this.pageDesignHeaders.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignHeaders.Size = new System.Drawing.Size(462, 524);
             this.pageDesignHeaders.Text = "Design Headers";
             this.pageDesignHeaders.TextDescription = "Primary is intended for main headers that provide section titles.";
             this.pageDesignHeaders.TextTitle = "Primary";
@@ -2840,10 +2698,9 @@ namespace PaletteDesigner
             // 
             this.header1Normal.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.header1Normal.HeaderStyle = Krypton.Toolkit.HeaderStyle.Secondary;
-            this.header1Normal.Location = new System.Drawing.Point(167, 119);
-            this.header1Normal.Margin = new System.Windows.Forms.Padding(4);
+            this.header1Normal.Location = new System.Drawing.Point(125, 97);
             this.header1Normal.Name = "header1Normal";
-            this.header1Normal.Size = new System.Drawing.Size(293, 34);
+            this.header1Normal.Size = new System.Drawing.Size(220, 28);
             this.header1Normal.TabIndex = 4;
             this.header1Normal.Values.Description = "Normal";
             this.header1Normal.Values.Heading = "Normal";
@@ -2852,10 +2709,9 @@ namespace PaletteDesigner
             // header1Disabled
             // 
             this.header1Disabled.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
-            this.header1Disabled.Location = new System.Drawing.Point(167, 38);
-            this.header1Disabled.Margin = new System.Windows.Forms.Padding(4);
+            this.header1Disabled.Location = new System.Drawing.Point(125, 31);
             this.header1Disabled.Name = "header1Disabled";
-            this.header1Disabled.Size = new System.Drawing.Size(293, 46);
+            this.header1Disabled.Size = new System.Drawing.Size(220, 37);
             this.header1Disabled.TabIndex = 3;
             this.header1Disabled.Values.Description = "Disabled";
             this.header1Disabled.Values.Heading = "Disabled";
@@ -2864,11 +2720,10 @@ namespace PaletteDesigner
             // borderDesignHeaders
             // 
             this.borderDesignHeaders.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignHeaders.Location = new System.Drawing.Point(111, 0);
-            this.borderDesignHeaders.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignHeaders.Location = new System.Drawing.Point(91, 0);
             this.borderDesignHeaders.Name = "borderDesignHeaders";
             this.borderDesignHeaders.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignHeaders.Size = new System.Drawing.Size(1, 645);
+            this.borderDesignHeaders.Size = new System.Drawing.Size(1, 524);
             this.borderDesignHeaders.TabIndex = 2;
             // 
             // kryptonNavigatorDesignHeaders
@@ -2901,8 +2756,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignHeaders.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignHeaders.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignHeaders.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignHeaders.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignHeaders.Name = "kryptonNavigatorDesignHeaders";
             this.kryptonNavigatorDesignHeaders.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignHeaders.Owner = null;
             this.kryptonNavigatorDesignHeaders.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -2917,7 +2770,7 @@ namespace PaletteDesigner
             this.pageHeadersCustom2});
             this.kryptonNavigatorDesignHeaders.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignHeaders.SelectedIndex = 7;
-            this.kryptonNavigatorDesignHeaders.Size = new System.Drawing.Size(111, 645);
+            this.kryptonNavigatorDesignHeaders.Size = new System.Drawing.Size(91, 524);
             this.kryptonNavigatorDesignHeaders.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignHeaders.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignHeaders.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -2934,10 +2787,9 @@ namespace PaletteDesigner
             this.pageHeadersPrimary.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersPrimary.ImageLarge")));
             this.pageHeadersPrimary.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersPrimary.ImageMedium")));
             this.pageHeadersPrimary.LastVisibleSet = true;
-            this.pageHeadersPrimary.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersPrimary.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersPrimary.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersPrimary.Name = "pageHeadersPrimary";
-            this.pageHeadersPrimary.Size = new System.Drawing.Size(67, 615);
+            this.pageHeadersPrimary.Size = new System.Drawing.Size(50, 500);
             this.pageHeadersPrimary.Text = "Primary";
             this.pageHeadersPrimary.TextDescription = "Primary is intended for main headers that provide section titles.";
             this.pageHeadersPrimary.ToolTipTitle = "Page ToolTip";
@@ -2950,10 +2802,9 @@ namespace PaletteDesigner
             this.pageHeadersSecondary.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersSecondary.ImageLarge")));
             this.pageHeadersSecondary.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersSecondary.ImageMedium")));
             this.pageHeadersSecondary.LastVisibleSet = true;
-            this.pageHeadersSecondary.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersSecondary.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersSecondary.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersSecondary.Name = "pageHeadersSecondary";
-            this.pageHeadersSecondary.Size = new System.Drawing.Size(67, 615);
+            this.pageHeadersSecondary.Size = new System.Drawing.Size(50, 500);
             this.pageHeadersSecondary.Text = "Secondary";
             this.pageHeadersSecondary.TextDescription = "Secondary is intended for headers that provide subsiduary titles.";
             this.pageHeadersSecondary.ToolTipTitle = "Page ToolTip";
@@ -2964,10 +2815,9 @@ namespace PaletteDesigner
             this.pageHeadersDockActive.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageHeadersDockActive.Flags = 65535;
             this.pageHeadersDockActive.LastVisibleSet = true;
-            this.pageHeadersDockActive.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersDockActive.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersDockActive.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersDockActive.Name = "pageHeadersDockActive";
-            this.pageHeadersDockActive.Size = new System.Drawing.Size(133, 123);
+            this.pageHeadersDockActive.Size = new System.Drawing.Size(100, 100);
             this.pageHeadersDockActive.Text = "Dock Active";
             this.pageHeadersDockActive.ToolTipTitle = "Page ToolTip";
             this.pageHeadersDockActive.UniqueName = "72D516AF5DB94F2872D516AF5DB94F28";
@@ -2977,10 +2827,9 @@ namespace PaletteDesigner
             this.pageHeadersDockInactive.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageHeadersDockInactive.Flags = 65535;
             this.pageHeadersDockInactive.LastVisibleSet = true;
-            this.pageHeadersDockInactive.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersDockInactive.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersDockInactive.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersDockInactive.Name = "pageHeadersDockInactive";
-            this.pageHeadersDockInactive.Size = new System.Drawing.Size(133, 123);
+            this.pageHeadersDockInactive.Size = new System.Drawing.Size(100, 100);
             this.pageHeadersDockInactive.Text = "Dock Inactive";
             this.pageHeadersDockInactive.ToolTipTitle = "Page ToolTip";
             this.pageHeadersDockInactive.UniqueName = "C2A22856527D4EADC2A22856527D4EAD";
@@ -2990,10 +2839,9 @@ namespace PaletteDesigner
             this.pageHeadersCalendar.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageHeadersCalendar.Flags = 65535;
             this.pageHeadersCalendar.LastVisibleSet = true;
-            this.pageHeadersCalendar.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersCalendar.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersCalendar.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersCalendar.Name = "pageHeadersCalendar";
-            this.pageHeadersCalendar.Size = new System.Drawing.Size(133, 123);
+            this.pageHeadersCalendar.Size = new System.Drawing.Size(100, 100);
             this.pageHeadersCalendar.Text = "Calendar";
             this.pageHeadersCalendar.TextDescription = "Calendar is used by the header for each month within the month calendar.";
             this.pageHeadersCalendar.ToolTipTitle = "Page ToolTip";
@@ -3004,10 +2852,9 @@ namespace PaletteDesigner
             this.pageHeadersForm.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageHeadersForm.Flags = 65535;
             this.pageHeadersForm.LastVisibleSet = true;
-            this.pageHeadersForm.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersForm.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersForm.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersForm.Name = "pageHeadersForm";
-            this.pageHeadersForm.Size = new System.Drawing.Size(133, 123);
+            this.pageHeadersForm.Size = new System.Drawing.Size(100, 100);
             this.pageHeadersForm.Text = "Form";
             this.pageHeadersForm.TextDescription = "Form style is used for a KryptonForm caption.";
             this.pageHeadersForm.ToolTipTitle = "Page ToolTip";
@@ -3020,10 +2867,9 @@ namespace PaletteDesigner
             this.pageHeadersCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersCustom1.ImageLarge")));
             this.pageHeadersCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersCustom1.ImageMedium")));
             this.pageHeadersCustom1.LastVisibleSet = true;
-            this.pageHeadersCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersCustom1.Name = "pageHeadersCustom1";
-            this.pageHeadersCustom1.Size = new System.Drawing.Size(67, 615);
+            this.pageHeadersCustom1.Size = new System.Drawing.Size(50, 500);
             this.pageHeadersCustom1.Text = "Custom 1";
             this.pageHeadersCustom1.TextDescription = "Custom 1 style inherits from Primary and is intended for your own custom use.";
             this.pageHeadersCustom1.ToolTipTitle = "Page ToolTip";
@@ -3036,10 +2882,9 @@ namespace PaletteDesigner
             this.pageHeadersCustom2.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersCustom2.ImageLarge")));
             this.pageHeadersCustom2.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageHeadersCustom2.ImageMedium")));
             this.pageHeadersCustom2.LastVisibleSet = true;
-            this.pageHeadersCustom2.Margin = new System.Windows.Forms.Padding(4);
-            this.pageHeadersCustom2.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageHeadersCustom2.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageHeadersCustom2.Name = "pageHeadersCustom2";
-            this.pageHeadersCustom2.Size = new System.Drawing.Size(67, 615);
+            this.pageHeadersCustom2.Size = new System.Drawing.Size(50, 500);
             this.pageHeadersCustom2.Text = "Custom 2";
             this.pageHeadersCustom2.TextDescription = "Custom 2 style inherits from Primary and is intended for your own custom use.";
             this.pageHeadersCustom2.ToolTipTitle = "Page ToolTip";
@@ -3054,10 +2899,9 @@ namespace PaletteDesigner
             this.pageDesignDateTime.Controls.Add(this.monthCalendarEnabled);
             this.pageDesignDateTime.Flags = 65535;
             this.pageDesignDateTime.LastVisibleSet = true;
-            this.pageDesignDateTime.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignDateTime.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignDateTime.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignDateTime.Name = "pageDesignDateTime";
-            this.pageDesignDateTime.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignDateTime.Size = new System.Drawing.Size(462, 524);
             this.pageDesignDateTime.Text = "Design Date Time";
             this.pageDesignDateTime.TextDescription = "View how the date time related styles are drawn.";
             this.pageDesignDateTime.TextTitle = "";
@@ -3070,10 +2914,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonLabel6.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.kryptonLabel6.Location = new System.Drawing.Point(32, 26);
-            this.kryptonLabel6.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel6.Location = new System.Drawing.Point(24, 21);
             this.kryptonLabel6.Name = "kryptonLabel6";
-            this.kryptonLabel6.Size = new System.Drawing.Size(96, 35);
+            this.kryptonLabel6.Size = new System.Drawing.Size(78, 29);
             this.kryptonLabel6.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonLabel6.TabIndex = 0;
             this.kryptonLabel6.Values.Text = "Normal";
@@ -3084,10 +2927,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonLabel7.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.kryptonLabel7.Location = new System.Drawing.Point(32, 330);
-            this.kryptonLabel7.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel7.Location = new System.Drawing.Point(24, 268);
             this.kryptonLabel7.Name = "kryptonLabel7";
-            this.kryptonLabel7.Size = new System.Drawing.Size(108, 35);
+            this.kryptonLabel7.Size = new System.Drawing.Size(88, 29);
             this.kryptonLabel7.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonLabel7.TabIndex = 1;
             this.kryptonLabel7.Values.Text = "Disabled";
@@ -3095,25 +2937,23 @@ namespace PaletteDesigner
             // monthCalendarDisabled
             // 
             this.monthCalendarDisabled.Enabled = false;
-            this.monthCalendarDisabled.Location = new System.Drawing.Point(32, 373);
-            this.monthCalendarDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.monthCalendarDisabled.Location = new System.Drawing.Point(24, 303);
             this.monthCalendarDisabled.Name = "monthCalendarDisabled";
             this.monthCalendarDisabled.SelectionEnd = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             this.monthCalendarDisabled.SelectionStart = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             this.monthCalendarDisabled.ShowWeekNumbers = true;
-            this.monthCalendarDisabled.Size = new System.Drawing.Size(328, 218);
+            this.monthCalendarDisabled.Size = new System.Drawing.Size(259, 182);
             this.monthCalendarDisabled.TabIndex = 1;
             this.monthCalendarDisabled.TodayDate = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             // 
             // monthCalendarEnabled
             // 
-            this.monthCalendarEnabled.Location = new System.Drawing.Point(32, 68);
-            this.monthCalendarEnabled.Margin = new System.Windows.Forms.Padding(4);
+            this.monthCalendarEnabled.Location = new System.Drawing.Point(24, 55);
             this.monthCalendarEnabled.Name = "monthCalendarEnabled";
             this.monthCalendarEnabled.SelectionEnd = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             this.monthCalendarEnabled.SelectionStart = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             this.monthCalendarEnabled.ShowWeekNumbers = true;
-            this.monthCalendarEnabled.Size = new System.Drawing.Size(328, 218);
+            this.monthCalendarEnabled.Size = new System.Drawing.Size(259, 182);
             this.monthCalendarEnabled.TabIndex = 0;
             this.monthCalendarEnabled.TodayDate = new System.DateTime(2009, 7, 24, 0, 0, 0, 0);
             // 
@@ -3132,10 +2972,9 @@ namespace PaletteDesigner
             this.pageDesignLabels.Controls.Add(this.kryptonNavigatorDesignLabels);
             this.pageDesignLabels.Flags = 65535;
             this.pageDesignLabels.LastVisibleSet = true;
-            this.pageDesignLabels.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignLabels.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignLabels.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignLabels.Name = "pageDesignLabels";
-            this.pageDesignLabels.Size = new System.Drawing.Size(859, 672);
+            this.pageDesignLabels.Size = new System.Drawing.Size(644, 546);
             this.pageDesignLabels.Text = "Design Labels";
             this.pageDesignLabels.TextDescription = "Normal is appropriate for standard control labelling. ";
             this.pageDesignLabels.TextTitle = "Normal";
@@ -3145,10 +2984,9 @@ namespace PaletteDesigner
             // labelsControlToolTip
             // 
             this.labelsControlToolTip.AutoSize = true;
-            this.labelsControlToolTip.Location = new System.Drawing.Point(429, 262);
-            this.labelsControlToolTip.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsControlToolTip.Location = new System.Drawing.Point(322, 213);
             this.labelsControlToolTip.Name = "labelsControlToolTip";
-            this.labelsControlToolTip.Size = new System.Drawing.Size(168, 32);
+            this.labelsControlToolTip.Size = new System.Drawing.Size(126, 26);
             this.labelsControlToolTip.TabIndex = 29;
             this.labelsControlToolTip.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsControlToolTip.Values.Text = "Control - ToolTip";
@@ -3156,10 +2994,9 @@ namespace PaletteDesigner
             // labelsControlCustom1
             // 
             this.labelsControlCustom1.AutoSize = true;
-            this.labelsControlCustom1.Location = new System.Drawing.Point(429, 308);
-            this.labelsControlCustom1.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsControlCustom1.Location = new System.Drawing.Point(322, 250);
             this.labelsControlCustom1.Name = "labelsControlCustom1";
-            this.labelsControlCustom1.Size = new System.Drawing.Size(187, 32);
+            this.labelsControlCustom1.Size = new System.Drawing.Size(140, 26);
             this.labelsControlCustom1.TabIndex = 28;
             this.labelsControlCustom1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsControlCustom1.Values.Text = "Control - Custom 1";
@@ -3167,10 +3004,9 @@ namespace PaletteDesigner
             // labelsControlAlternate
             // 
             this.labelsControlAlternate.AutoSize = true;
-            this.labelsControlAlternate.Location = new System.Drawing.Point(429, 217);
-            this.labelsControlAlternate.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsControlAlternate.Location = new System.Drawing.Point(322, 176);
             this.labelsControlAlternate.Name = "labelsControlAlternate";
-            this.labelsControlAlternate.Size = new System.Drawing.Size(183, 32);
+            this.labelsControlAlternate.Size = new System.Drawing.Size(137, 26);
             this.labelsControlAlternate.TabIndex = 27;
             this.labelsControlAlternate.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsControlAlternate.Values.Text = "Control - Alternate";
@@ -3178,10 +3014,9 @@ namespace PaletteDesigner
             // labelsControlClient
             // 
             this.labelsControlClient.AutoSize = true;
-            this.labelsControlClient.Location = new System.Drawing.Point(429, 171);
-            this.labelsControlClient.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsControlClient.Location = new System.Drawing.Point(322, 139);
             this.labelsControlClient.Name = "labelsControlClient";
-            this.labelsControlClient.Size = new System.Drawing.Size(153, 32);
+            this.labelsControlClient.Size = new System.Drawing.Size(115, 26);
             this.labelsControlClient.TabIndex = 26;
             this.labelsControlClient.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsControlClient.Values.Text = "Control - Client";
@@ -3189,10 +3024,9 @@ namespace PaletteDesigner
             // labelsPanelCustom1
             // 
             this.labelsPanelCustom1.AutoSize = true;
-            this.labelsPanelCustom1.Location = new System.Drawing.Point(429, 126);
-            this.labelsPanelCustom1.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsPanelCustom1.Location = new System.Drawing.Point(322, 102);
             this.labelsPanelCustom1.Name = "labelsPanelCustom1";
-            this.labelsPanelCustom1.Size = new System.Drawing.Size(168, 32);
+            this.labelsPanelCustom1.Size = new System.Drawing.Size(126, 26);
             this.labelsPanelCustom1.TabIndex = 25;
             this.labelsPanelCustom1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsPanelCustom1.Values.Text = "Panel - Custom 1";
@@ -3200,10 +3034,9 @@ namespace PaletteDesigner
             // labelsPanelAlternate
             // 
             this.labelsPanelAlternate.AutoSize = true;
-            this.labelsPanelAlternate.Location = new System.Drawing.Point(429, 80);
-            this.labelsPanelAlternate.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsPanelAlternate.Location = new System.Drawing.Point(322, 65);
             this.labelsPanelAlternate.Name = "labelsPanelAlternate";
-            this.labelsPanelAlternate.Size = new System.Drawing.Size(165, 32);
+            this.labelsPanelAlternate.Size = new System.Drawing.Size(124, 26);
             this.labelsPanelAlternate.TabIndex = 24;
             this.labelsPanelAlternate.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsPanelAlternate.Values.Text = "Panel - Alternate";
@@ -3212,10 +3045,9 @@ namespace PaletteDesigner
             // 
             this.labelsPanelClient.AutoSize = true;
             this.labelsPanelClient.Checked = true;
-            this.labelsPanelClient.Location = new System.Drawing.Point(429, 34);
-            this.labelsPanelClient.Margin = new System.Windows.Forms.Padding(4);
+            this.labelsPanelClient.Location = new System.Drawing.Point(322, 28);
             this.labelsPanelClient.Name = "labelsPanelClient";
-            this.labelsPanelClient.Size = new System.Drawing.Size(153, 32);
+            this.labelsPanelClient.Size = new System.Drawing.Size(115, 26);
             this.labelsPanelClient.TabIndex = 23;
             this.labelsPanelClient.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.labelsPanelClient.Values.Text = "Panel - Client";
@@ -3228,19 +3060,17 @@ namespace PaletteDesigner
             this.panelLabelsBackground.Controls.Add(this.label1Pressed);
             this.panelLabelsBackground.Controls.Add(this.label1NotVisited);
             this.panelLabelsBackground.Controls.Add(this.label1Visited);
-            this.panelLabelsBackground.Location = new System.Drawing.Point(167, 34);
-            this.panelLabelsBackground.Margin = new System.Windows.Forms.Padding(4);
+            this.panelLabelsBackground.Location = new System.Drawing.Point(125, 28);
             this.panelLabelsBackground.Name = "panelLabelsBackground";
-            this.panelLabelsBackground.Size = new System.Drawing.Size(239, 372);
+            this.panelLabelsBackground.Size = new System.Drawing.Size(179, 302);
             this.panelLabelsBackground.TabIndex = 22;
             // 
             // label1Disabled
             // 
             this.label1Disabled.Enabled = false;
-            this.label1Disabled.Location = new System.Drawing.Point(13, 26);
-            this.label1Disabled.Margin = new System.Windows.Forms.Padding(4);
+            this.label1Disabled.Location = new System.Drawing.Point(10, 21);
             this.label1Disabled.Name = "label1Disabled";
-            this.label1Disabled.Size = new System.Drawing.Size(139, 24);
+            this.label1Disabled.Size = new System.Drawing.Size(117, 20);
             this.label1Disabled.TabIndex = 0;
             this.label1Disabled.Values.ExtraText = "(Label)";
             this.label1Disabled.Values.Image = global::PaletteDesigner.Properties.Resources.environment;
@@ -3248,10 +3078,9 @@ namespace PaletteDesigner
             // 
             // label1Live
             // 
-            this.label1Live.Location = new System.Drawing.Point(13, 315);
-            this.label1Live.Margin = new System.Windows.Forms.Padding(4);
+            this.label1Live.Location = new System.Drawing.Point(10, 256);
             this.label1Live.Name = "label1Live";
-            this.label1Live.Size = new System.Drawing.Size(134, 24);
+            this.label1Live.Size = new System.Drawing.Size(113, 20);
             this.label1Live.TabIndex = 1;
             this.label1Live.Values.ExtraText = "(LinkLabel)";
             this.label1Live.Values.Image = ((System.Drawing.Image)(resources.GetObject("label1Live.Values.Image")));
@@ -3260,10 +3089,9 @@ namespace PaletteDesigner
             // label1Normal
             // 
             this.label1Normal.Enabled = false;
-            this.label1Normal.Location = new System.Drawing.Point(13, 84);
-            this.label1Normal.Margin = new System.Windows.Forms.Padding(4);
+            this.label1Normal.Location = new System.Drawing.Point(10, 68);
             this.label1Normal.Name = "label1Normal";
-            this.label1Normal.Size = new System.Drawing.Size(131, 24);
+            this.label1Normal.Size = new System.Drawing.Size(110, 20);
             this.label1Normal.TabIndex = 2;
             this.label1Normal.Values.ExtraText = "(Label)";
             this.label1Normal.Values.Image = global::PaletteDesigner.Properties.Resources.environment;
@@ -3272,10 +3100,9 @@ namespace PaletteDesigner
             // label1Pressed
             // 
             this.label1Pressed.Enabled = false;
-            this.label1Pressed.Location = new System.Drawing.Point(13, 258);
-            this.label1Pressed.Margin = new System.Windows.Forms.Padding(4);
+            this.label1Pressed.Location = new System.Drawing.Point(10, 210);
             this.label1Pressed.Name = "label1Pressed";
-            this.label1Pressed.Size = new System.Drawing.Size(160, 24);
+            this.label1Pressed.Size = new System.Drawing.Size(133, 20);
             this.label1Pressed.TabIndex = 3;
             this.label1Pressed.Values.ExtraText = "(LinkLabel)";
             this.label1Pressed.Values.Image = ((System.Drawing.Image)(resources.GetObject("label1Pressed.Values.Image")));
@@ -3284,10 +3111,9 @@ namespace PaletteDesigner
             // label1NotVisited
             // 
             this.label1NotVisited.Enabled = false;
-            this.label1NotVisited.Location = new System.Drawing.Point(13, 142);
-            this.label1NotVisited.Margin = new System.Windows.Forms.Padding(4);
+            this.label1NotVisited.Location = new System.Drawing.Point(10, 115);
             this.label1NotVisited.Name = "label1NotVisited";
-            this.label1NotVisited.Size = new System.Drawing.Size(179, 24);
+            this.label1NotVisited.Size = new System.Drawing.Size(149, 20);
             this.label1NotVisited.TabIndex = 4;
             this.label1NotVisited.Values.ExtraText = "(LinkLabel)";
             this.label1NotVisited.Values.Image = ((System.Drawing.Image)(resources.GetObject("label1NotVisited.Values.Image")));
@@ -3297,10 +3123,9 @@ namespace PaletteDesigner
             // 
             this.label1Visited.Enabled = false;
             this.label1Visited.LinkVisited = true;
-            this.label1Visited.Location = new System.Drawing.Point(13, 199);
-            this.label1Visited.Margin = new System.Windows.Forms.Padding(4);
+            this.label1Visited.Location = new System.Drawing.Point(10, 162);
             this.label1Visited.Name = "label1Visited";
-            this.label1Visited.Size = new System.Drawing.Size(154, 24);
+            this.label1Visited.Size = new System.Drawing.Size(128, 20);
             this.label1Visited.TabIndex = 5;
             this.label1Visited.Values.ExtraText = "(LinkLabel)";
             this.label1Visited.Values.Image = ((System.Drawing.Image)(resources.GetObject("label1Visited.Values.Image")));
@@ -3309,11 +3134,10 @@ namespace PaletteDesigner
             // borderDesignLabels
             // 
             this.borderDesignLabels.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignLabels.Location = new System.Drawing.Point(135, 0);
-            this.borderDesignLabels.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignLabels.Location = new System.Drawing.Point(111, 0);
             this.borderDesignLabels.Name = "borderDesignLabels";
             this.borderDesignLabels.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignLabels.Size = new System.Drawing.Size(1, 672);
+            this.borderDesignLabels.Size = new System.Drawing.Size(1, 546);
             this.borderDesignLabels.TabIndex = 2;
             // 
             // kryptonNavigatorDesignLabels
@@ -3346,8 +3170,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignLabels.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignLabels.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignLabels.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignLabels.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignLabels.Name = "kryptonNavigatorDesignLabels";
             this.kryptonNavigatorDesignLabels.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignLabels.Owner = null;
             this.kryptonNavigatorDesignLabels.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -3369,7 +3191,7 @@ namespace PaletteDesigner
             this.pageLabelsCustom3});
             this.kryptonNavigatorDesignLabels.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignLabels.SelectedIndex = 0;
-            this.kryptonNavigatorDesignLabels.Size = new System.Drawing.Size(135, 672);
+            this.kryptonNavigatorDesignLabels.Size = new System.Drawing.Size(111, 546);
             this.kryptonNavigatorDesignLabels.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignLabels.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignLabels.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -3386,10 +3208,9 @@ namespace PaletteDesigner
             this.pageLabelsNormalControl.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsNormalControl.ImageLarge")));
             this.pageLabelsNormalControl.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsNormalControl.ImageMedium")));
             this.pageLabelsNormalControl.LastVisibleSet = true;
-            this.pageLabelsNormalControl.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsNormalControl.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsNormalControl.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsNormalControl.Name = "pageLabelsNormalControl";
-            this.pageLabelsNormalControl.Size = new System.Drawing.Size(67, 615);
+            this.pageLabelsNormalControl.Size = new System.Drawing.Size(50, 500);
             this.pageLabelsNormalControl.Text = "Normal (Control)";
             this.pageLabelsNormalControl.TextDescription = "Normal is appropriate for standard control labelling on control background.";
             this.pageLabelsNormalControl.ToolTipTitle = "Page ToolTip";
@@ -3400,10 +3221,9 @@ namespace PaletteDesigner
             this.pageLabelsBoldControl.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsBoldControl.Flags = 65534;
             this.pageLabelsBoldControl.LastVisibleSet = true;
-            this.pageLabelsBoldControl.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsBoldControl.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsBoldControl.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsBoldControl.Name = "pageLabelsBoldControl";
-            this.pageLabelsBoldControl.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsBoldControl.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsBoldControl.Text = "Bold (Control)";
             this.pageLabelsBoldControl.TextDescription = "Bold is appropriate for a title labelling on control background.";
             this.pageLabelsBoldControl.ToolTipTitle = "Page ToolTip";
@@ -3414,10 +3234,9 @@ namespace PaletteDesigner
             this.pageLabelsItalicControl.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsItalicControl.Flags = 65534;
             this.pageLabelsItalicControl.LastVisibleSet = true;
-            this.pageLabelsItalicControl.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsItalicControl.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsItalicControl.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsItalicControl.Name = "pageLabelsItalicControl";
-            this.pageLabelsItalicControl.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsItalicControl.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsItalicControl.Text = "Italic (Control)";
             this.pageLabelsItalicControl.TextDescription = "Italic is appropriate for emphasised labelling on control background.";
             this.pageLabelsItalicControl.ToolTipTitle = "Page ToolTip";
@@ -3430,10 +3249,9 @@ namespace PaletteDesigner
             this.pageLabelsTitleControl.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsTitleControl.ImageLarge")));
             this.pageLabelsTitleControl.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsTitleControl.ImageMedium")));
             this.pageLabelsTitleControl.LastVisibleSet = true;
-            this.pageLabelsTitleControl.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsTitleControl.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsTitleControl.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsTitleControl.Name = "pageLabelsTitleControl";
-            this.pageLabelsTitleControl.Size = new System.Drawing.Size(67, 615);
+            this.pageLabelsTitleControl.Size = new System.Drawing.Size(50, 500);
             this.pageLabelsTitleControl.Text = "Title (Control)";
             this.pageLabelsTitleControl.TextDescription = "Title provides a section level heading label on a control background.";
             this.pageLabelsTitleControl.ToolTipTitle = "Page ToolTip";
@@ -3444,10 +3262,9 @@ namespace PaletteDesigner
             this.pageLabelsNormalPanel.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsNormalPanel.Flags = 65535;
             this.pageLabelsNormalPanel.LastVisibleSet = true;
-            this.pageLabelsNormalPanel.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsNormalPanel.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsNormalPanel.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsNormalPanel.Name = "pageLabelsNormalPanel";
-            this.pageLabelsNormalPanel.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsNormalPanel.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsNormalPanel.Text = "Normal (Panel)";
             this.pageLabelsNormalPanel.TextDescription = "Normal is appropriate for standard control labelling on panel background.";
             this.pageLabelsNormalPanel.ToolTipTitle = "Page ToolTip";
@@ -3458,10 +3275,9 @@ namespace PaletteDesigner
             this.pageLabelsBoldPanel.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsBoldPanel.Flags = 65534;
             this.pageLabelsBoldPanel.LastVisibleSet = true;
-            this.pageLabelsBoldPanel.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsBoldPanel.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsBoldPanel.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsBoldPanel.Name = "pageLabelsBoldPanel";
-            this.pageLabelsBoldPanel.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsBoldPanel.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsBoldPanel.Text = "Bold (Panel)";
             this.pageLabelsBoldPanel.TextDescription = "Bold is appropriate for a title labelling on panel background.";
             this.pageLabelsBoldPanel.ToolTipTitle = "Page ToolTip";
@@ -3472,10 +3288,9 @@ namespace PaletteDesigner
             this.pageLabelsItalicPanel.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsItalicPanel.Flags = 65534;
             this.pageLabelsItalicPanel.LastVisibleSet = true;
-            this.pageLabelsItalicPanel.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsItalicPanel.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsItalicPanel.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsItalicPanel.Name = "pageLabelsItalicPanel";
-            this.pageLabelsItalicPanel.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsItalicPanel.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsItalicPanel.Text = "Italic (Panel)";
             this.pageLabelsItalicPanel.TextDescription = "Bold is appropriate for emphasised labelling on panel background.";
             this.pageLabelsItalicPanel.ToolTipTitle = "Page ToolTip";
@@ -3486,10 +3301,9 @@ namespace PaletteDesigner
             this.pageLabelsTitlePanel.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsTitlePanel.Flags = 65535;
             this.pageLabelsTitlePanel.LastVisibleSet = true;
-            this.pageLabelsTitlePanel.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsTitlePanel.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsTitlePanel.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsTitlePanel.Name = "pageLabelsTitlePanel";
-            this.pageLabelsTitlePanel.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsTitlePanel.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsTitlePanel.Text = "Title (Panel)";
             this.pageLabelsTitlePanel.TextDescription = "Title provides a section level heading label on a panel background.";
             this.pageLabelsTitlePanel.ToolTipTitle = "Page ToolTip";
@@ -3500,10 +3314,9 @@ namespace PaletteDesigner
             this.pageLabelsGroupBoxCaption.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsGroupBoxCaption.Flags = 65534;
             this.pageLabelsGroupBoxCaption.LastVisibleSet = true;
-            this.pageLabelsGroupBoxCaption.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsGroupBoxCaption.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsGroupBoxCaption.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsGroupBoxCaption.Name = "pageLabelsGroupBoxCaption";
-            this.pageLabelsGroupBoxCaption.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsGroupBoxCaption.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsGroupBoxCaption.Text = "GroupBox";
             this.pageLabelsGroupBoxCaption.TextDescription = "GroupBox is used as the default for KryptonGroupBox captions.";
             this.pageLabelsGroupBoxCaption.ToolTipTitle = "Page ToolTip";
@@ -3514,10 +3327,9 @@ namespace PaletteDesigner
             this.pageLabelsToolTip.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsToolTip.Flags = 65535;
             this.pageLabelsToolTip.LastVisibleSet = true;
-            this.pageLabelsToolTip.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsToolTip.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsToolTip.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsToolTip.Name = "pageLabelsToolTip";
-            this.pageLabelsToolTip.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsToolTip.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsToolTip.Text = "ToolTip";
             this.pageLabelsToolTip.TextDescription = "ToolTip is used for popup windows showing additional context information. ";
             this.pageLabelsToolTip.ToolTipTitle = "Page ToolTip";
@@ -3528,10 +3340,9 @@ namespace PaletteDesigner
             this.pageLabelsSuperTip.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsSuperTip.Flags = 65535;
             this.pageLabelsSuperTip.LastVisibleSet = true;
-            this.pageLabelsSuperTip.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsSuperTip.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsSuperTip.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsSuperTip.Name = "pageLabelsSuperTip";
-            this.pageLabelsSuperTip.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsSuperTip.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsSuperTip.Text = "SuperTip";
             this.pageLabelsSuperTip.TextDescription = "SuperTip is used for tool tips that have extensive information presented. ";
             this.pageLabelsSuperTip.ToolTipTitle = "Page ToolTip";
@@ -3542,10 +3353,9 @@ namespace PaletteDesigner
             this.pageLabelsKeyTip.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageLabelsKeyTip.Flags = 65535;
             this.pageLabelsKeyTip.LastVisibleSet = true;
-            this.pageLabelsKeyTip.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsKeyTip.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsKeyTip.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsKeyTip.Name = "pageLabelsKeyTip";
-            this.pageLabelsKeyTip.Size = new System.Drawing.Size(133, 123);
+            this.pageLabelsKeyTip.Size = new System.Drawing.Size(100, 100);
             this.pageLabelsKeyTip.Text = "KeyTip";
             this.pageLabelsKeyTip.TextDescription = "KeyTip is used for key tips that are available from the Ribbon control.";
             this.pageLabelsKeyTip.ToolTipTitle = "Page ToolTip";
@@ -3558,11 +3368,10 @@ namespace PaletteDesigner
             this.pageLabelsCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom1.ImageLarge")));
             this.pageLabelsCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom1.ImageMedium")));
             this.pageLabelsCustom1.LastVisibleSet = true;
-            this.pageLabelsCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsCustom1.Name = "pageLabelsCustom1";
             this.pageLabelsCustom1.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.pageLabelsCustom1.Size = new System.Drawing.Size(67, 615);
+            this.pageLabelsCustom1.Size = new System.Drawing.Size(50, 500);
             this.pageLabelsCustom1.Text = "Custom 1";
             this.pageLabelsCustom1.TextDescription = "Custom 1 style inherits from Normal and is intended for your own custom use.";
             this.pageLabelsCustom1.ToolTipTitle = "Page ToolTip";
@@ -3575,10 +3384,9 @@ namespace PaletteDesigner
             this.pageLabelsCustom2.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom2.ImageLarge")));
             this.pageLabelsCustom2.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom2.ImageMedium")));
             this.pageLabelsCustom2.LastVisibleSet = true;
-            this.pageLabelsCustom2.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsCustom2.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsCustom2.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsCustom2.Name = "pageLabelsCustom2";
-            this.pageLabelsCustom2.Size = new System.Drawing.Size(67, 615);
+            this.pageLabelsCustom2.Size = new System.Drawing.Size(50, 500);
             this.pageLabelsCustom2.Text = "Custom 2";
             this.pageLabelsCustom2.TextDescription = "Custom 2 style inherits from Normal and is intended for your own custom use.";
             this.pageLabelsCustom2.ToolTipTitle = "Page ToolTip";
@@ -3591,10 +3399,9 @@ namespace PaletteDesigner
             this.pageLabelsCustom3.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom3.ImageLarge")));
             this.pageLabelsCustom3.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageLabelsCustom3.ImageMedium")));
             this.pageLabelsCustom3.LastVisibleSet = true;
-            this.pageLabelsCustom3.Margin = new System.Windows.Forms.Padding(4);
-            this.pageLabelsCustom3.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageLabelsCustom3.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageLabelsCustom3.Name = "pageLabelsCustom3";
-            this.pageLabelsCustom3.Size = new System.Drawing.Size(67, 615);
+            this.pageLabelsCustom3.Size = new System.Drawing.Size(50, 500);
             this.pageLabelsCustom3.Text = "Custom 3";
             this.pageLabelsCustom3.TextDescription = "Custom 3 style inherits from Normal and is intended for your own custom use.";
             this.pageLabelsCustom3.ToolTipTitle = "Page ToolTip";
@@ -3611,10 +3418,9 @@ namespace PaletteDesigner
             this.pageDesignNavigator.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignNavigator.ImageMedium")));
             this.pageDesignNavigator.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignNavigator.ImageSmall")));
             this.pageDesignNavigator.LastVisibleSet = true;
-            this.pageDesignNavigator.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignNavigator.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignNavigator.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignNavigator.Name = "pageDesignNavigator";
-            this.pageDesignNavigator.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignNavigator.Size = new System.Drawing.Size(462, 524);
             this.pageDesignNavigator.Text = "Design Navigator";
             this.pageDesignNavigator.TextDescription = "Appearance of navigator when using Bar-CheckButton-Group-Outside mode.";
             this.pageDesignNavigator.TextTitle = "Bar Outside";
@@ -3624,11 +3430,10 @@ namespace PaletteDesigner
             // borderDesignNavigator
             // 
             this.borderDesignNavigator.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignNavigator.Location = new System.Drawing.Point(99, 0);
-            this.borderDesignNavigator.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignNavigator.Location = new System.Drawing.Point(82, 0);
             this.borderDesignNavigator.Name = "borderDesignNavigator";
             this.borderDesignNavigator.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignNavigator.Size = new System.Drawing.Size(1, 645);
+            this.borderDesignNavigator.Size = new System.Drawing.Size(1, 524);
             this.borderDesignNavigator.TabIndex = 2;
             // 
             // kryptonNavigatorDesignNavigator
@@ -3661,8 +3466,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignNavigator.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignNavigator.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignNavigator.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignNavigator.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignNavigator.Name = "kryptonNavigatorDesignNavigator";
             this.kryptonNavigatorDesignNavigator.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignNavigator.Owner = null;
             this.kryptonNavigatorDesignNavigator.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -3672,7 +3475,7 @@ namespace PaletteDesigner
             this.pageNavigatorBarCheckButtonGroupOnly});
             this.kryptonNavigatorDesignNavigator.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignNavigator.SelectedIndex = 0;
-            this.kryptonNavigatorDesignNavigator.Size = new System.Drawing.Size(99, 645);
+            this.kryptonNavigatorDesignNavigator.Size = new System.Drawing.Size(82, 524);
             this.kryptonNavigatorDesignNavigator.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignNavigator.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignNavigator.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -3689,10 +3492,9 @@ namespace PaletteDesigner
             this.pageNavigatorBarCheckButtonGroupOutside.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupOutside.ImageLarge")));
             this.pageNavigatorBarCheckButtonGroupOutside.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupOutside.ImageMedium")));
             this.pageNavigatorBarCheckButtonGroupOutside.LastVisibleSet = true;
-            this.pageNavigatorBarCheckButtonGroupOutside.Margin = new System.Windows.Forms.Padding(4);
-            this.pageNavigatorBarCheckButtonGroupOutside.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageNavigatorBarCheckButtonGroupOutside.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageNavigatorBarCheckButtonGroupOutside.Name = "pageNavigatorBarCheckButtonGroupOutside";
-            this.pageNavigatorBarCheckButtonGroupOutside.Size = new System.Drawing.Size(67, 615);
+            this.pageNavigatorBarCheckButtonGroupOutside.Size = new System.Drawing.Size(50, 500);
             this.pageNavigatorBarCheckButtonGroupOutside.Text = "Bar Outside";
             this.pageNavigatorBarCheckButtonGroupOutside.TextDescription = "Appearance of when using Bar-CheckButton-Group-Outside mode.";
             this.pageNavigatorBarCheckButtonGroupOutside.ToolTipTitle = "Page ToolTip";
@@ -3705,10 +3507,9 @@ namespace PaletteDesigner
             this.pageNavigatorBarCheckButtonGroupInside.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupInside.ImageLarge")));
             this.pageNavigatorBarCheckButtonGroupInside.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupInside.ImageMedium")));
             this.pageNavigatorBarCheckButtonGroupInside.LastVisibleSet = true;
-            this.pageNavigatorBarCheckButtonGroupInside.Margin = new System.Windows.Forms.Padding(4);
-            this.pageNavigatorBarCheckButtonGroupInside.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageNavigatorBarCheckButtonGroupInside.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageNavigatorBarCheckButtonGroupInside.Name = "pageNavigatorBarCheckButtonGroupInside";
-            this.pageNavigatorBarCheckButtonGroupInside.Size = new System.Drawing.Size(67, 615);
+            this.pageNavigatorBarCheckButtonGroupInside.Size = new System.Drawing.Size(50, 500);
             this.pageNavigatorBarCheckButtonGroupInside.Text = "Bar Inside";
             this.pageNavigatorBarCheckButtonGroupInside.TextDescription = "Appearance of when using Bar-CheckButton-Group-Inside mode.";
             this.pageNavigatorBarCheckButtonGroupInside.ToolTipTitle = "Page ToolTip";
@@ -3721,10 +3522,9 @@ namespace PaletteDesigner
             this.pageNavigatorBarCheckButtonGroupOnly.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupOnly.ImageLarge")));
             this.pageNavigatorBarCheckButtonGroupOnly.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageNavigatorBarCheckButtonGroupOnly.ImageMedium")));
             this.pageNavigatorBarCheckButtonGroupOnly.LastVisibleSet = true;
-            this.pageNavigatorBarCheckButtonGroupOnly.Margin = new System.Windows.Forms.Padding(4);
-            this.pageNavigatorBarCheckButtonGroupOnly.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageNavigatorBarCheckButtonGroupOnly.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageNavigatorBarCheckButtonGroupOnly.Name = "pageNavigatorBarCheckButtonGroupOnly";
-            this.pageNavigatorBarCheckButtonGroupOnly.Size = new System.Drawing.Size(67, 615);
+            this.pageNavigatorBarCheckButtonGroupOnly.Size = new System.Drawing.Size(50, 500);
             this.pageNavigatorBarCheckButtonGroupOnly.Text = "Bar Only";
             this.pageNavigatorBarCheckButtonGroupOnly.TextDescription = "Appearance of when using Bar-CheckButton-Group-Only mode.";
             this.pageNavigatorBarCheckButtonGroupOnly.ToolTipTitle = "Page ToolTip";
@@ -3744,9 +3544,7 @@ namespace PaletteDesigner
             this.kryptonNavigator.Button.PreviousButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
             this.kryptonNavigator.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
             this.kryptonNavigator.ControlKryptonFormFeatures = false;
-            this.kryptonNavigator.Location = new System.Drawing.Point(136, 34);
-            this.kryptonNavigator.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigator.Name = "kryptonNavigator";
+            this.kryptonNavigator.Location = new System.Drawing.Point(102, 28);
             this.kryptonNavigator.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
             this.kryptonNavigator.Owner = null;
             this.kryptonNavigator.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -3767,10 +3565,9 @@ namespace PaletteDesigner
             this.navigatorPage1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("navigatorPage1.ImageMedium")));
             this.navigatorPage1.ImageSmall = global::PaletteDesigner.Properties.Resources.environment;
             this.navigatorPage1.LastVisibleSet = true;
-            this.navigatorPage1.Margin = new System.Windows.Forms.Padding(4);
-            this.navigatorPage1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.navigatorPage1.MinimumSize = new System.Drawing.Size(50, 50);
             this.navigatorPage1.Name = "navigatorPage1";
-            this.navigatorPage1.Size = new System.Drawing.Size(303, 133);
+            this.navigatorPage1.Size = new System.Drawing.Size(303, 137);
             this.navigatorPage1.Text = "Page 1";
             this.navigatorPage1.TextDescription = "Page 1 Description";
             this.navigatorPage1.TextTitle = "Page 1 Title";
@@ -3785,10 +3582,9 @@ namespace PaletteDesigner
             this.navigatorPage2.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("navigatorPage2.ImageMedium")));
             this.navigatorPage2.ImageSmall = global::PaletteDesigner.Properties.Resources.document_new;
             this.navigatorPage2.LastVisibleSet = true;
-            this.navigatorPage2.Margin = new System.Windows.Forms.Padding(4);
-            this.navigatorPage2.MinimumSize = new System.Drawing.Size(67, 62);
+            this.navigatorPage2.MinimumSize = new System.Drawing.Size(50, 50);
             this.navigatorPage2.Name = "navigatorPage2";
-            this.navigatorPage2.Size = new System.Drawing.Size(377, 169);
+            this.navigatorPage2.Size = new System.Drawing.Size(283, 137);
             this.navigatorPage2.Text = "Page 2";
             this.navigatorPage2.TextDescription = "Page 2 Description";
             this.navigatorPage2.TextTitle = "Page 2 Title";
@@ -3803,10 +3599,9 @@ namespace PaletteDesigner
             this.navigatorPage3.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("navigatorPage3.ImageMedium")));
             this.navigatorPage3.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("navigatorPage3.ImageSmall")));
             this.navigatorPage3.LastVisibleSet = true;
-            this.navigatorPage3.Margin = new System.Windows.Forms.Padding(4);
-            this.navigatorPage3.MinimumSize = new System.Drawing.Size(67, 62);
+            this.navigatorPage3.MinimumSize = new System.Drawing.Size(50, 50);
             this.navigatorPage3.Name = "navigatorPage3";
-            this.navigatorPage3.Size = new System.Drawing.Size(377, 169);
+            this.navigatorPage3.Size = new System.Drawing.Size(283, 137);
             this.navigatorPage3.Text = "Page 3";
             this.navigatorPage3.TextDescription = "Page 3 Description";
             this.navigatorPage3.TextTitle = "Page 3 Title";
@@ -3827,10 +3622,9 @@ namespace PaletteDesigner
             this.pageDesignPanels.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignPanels.ImageMedium")));
             this.pageDesignPanels.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignPanels.ImageSmall")));
             this.pageDesignPanels.LastVisibleSet = true;
-            this.pageDesignPanels.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignPanels.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignPanels.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignPanels.Name = "pageDesignPanels";
-            this.pageDesignPanels.Size = new System.Drawing.Size(616, 658);
+            this.pageDesignPanels.Size = new System.Drawing.Size(462, 535);
             this.pageDesignPanels.Text = "Design Panels";
             this.pageDesignPanels.TextDescription = "Client is the main style for the client area of Krypton panels.";
             this.pageDesignPanels.TextTitle = "Client";
@@ -3839,18 +3633,16 @@ namespace PaletteDesigner
             // 
             // panel1Normal
             // 
-            this.panel1Normal.Location = new System.Drawing.Point(415, 76);
-            this.panel1Normal.Margin = new System.Windows.Forms.Padding(4);
+            this.panel1Normal.Location = new System.Drawing.Point(311, 62);
             this.panel1Normal.Name = "panel1Normal";
-            this.panel1Normal.Size = new System.Drawing.Size(133, 123);
+            this.panel1Normal.Size = new System.Drawing.Size(100, 100);
             this.panel1Normal.TabIndex = 19;
             // 
             // panel1Disabled
             // 
-            this.panel1Disabled.Location = new System.Drawing.Point(196, 76);
-            this.panel1Disabled.Margin = new System.Windows.Forms.Padding(4);
+            this.panel1Disabled.Location = new System.Drawing.Point(147, 62);
             this.panel1Disabled.Name = "panel1Disabled";
-            this.panel1Disabled.Size = new System.Drawing.Size(133, 123);
+            this.panel1Disabled.Size = new System.Drawing.Size(100, 100);
             this.panel1Disabled.TabIndex = 18;
             // 
             // labelPanelsNormal
@@ -3859,10 +3651,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelPanelsNormal.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelPanelsNormal.Location = new System.Drawing.Point(415, 37);
-            this.labelPanelsNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.labelPanelsNormal.Location = new System.Drawing.Point(311, 30);
             this.labelPanelsNormal.Name = "labelPanelsNormal";
-            this.labelPanelsNormal.Size = new System.Drawing.Size(96, 35);
+            this.labelPanelsNormal.Size = new System.Drawing.Size(78, 29);
             this.labelPanelsNormal.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelPanelsNormal.TabIndex = 20;
             this.labelPanelsNormal.Values.Text = "Normal";
@@ -3873,10 +3664,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelPanelsDisabled.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelPanelsDisabled.Location = new System.Drawing.Point(196, 37);
-            this.labelPanelsDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.labelPanelsDisabled.Location = new System.Drawing.Point(147, 30);
             this.labelPanelsDisabled.Name = "labelPanelsDisabled";
-            this.labelPanelsDisabled.Size = new System.Drawing.Size(108, 35);
+            this.labelPanelsDisabled.Size = new System.Drawing.Size(88, 29);
             this.labelPanelsDisabled.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelPanelsDisabled.TabIndex = 21;
             this.labelPanelsDisabled.Values.Text = "Disabled";
@@ -3884,11 +3674,10 @@ namespace PaletteDesigner
             // borderDesignPanels
             // 
             this.borderDesignPanels.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignPanels.Location = new System.Drawing.Point(125, 0);
-            this.borderDesignPanels.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignPanels.Location = new System.Drawing.Point(103, 0);
             this.borderDesignPanels.Name = "borderDesignPanels";
             this.borderDesignPanels.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignPanels.Size = new System.Drawing.Size(1, 658);
+            this.borderDesignPanels.Size = new System.Drawing.Size(1, 535);
             this.borderDesignPanels.TabIndex = 3;
             // 
             // kryptonNavigatorDesignPanels
@@ -3921,8 +3710,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignPanels.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignPanels.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignPanels.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignPanels.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignPanels.Name = "kryptonNavigatorDesignPanels";
             this.kryptonNavigatorDesignPanels.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignPanels.Owner = null;
             this.kryptonNavigatorDesignPanels.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -3933,7 +3720,7 @@ namespace PaletteDesigner
             this.pagePanelsCustom1});
             this.kryptonNavigatorDesignPanels.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignPanels.SelectedIndex = 0;
-            this.kryptonNavigatorDesignPanels.Size = new System.Drawing.Size(125, 658);
+            this.kryptonNavigatorDesignPanels.Size = new System.Drawing.Size(103, 535);
             this.kryptonNavigatorDesignPanels.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignPanels.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignPanels.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -3950,10 +3737,9 @@ namespace PaletteDesigner
             this.pagePanelsClient.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsClient.ImageLarge")));
             this.pagePanelsClient.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsClient.ImageMedium")));
             this.pagePanelsClient.LastVisibleSet = true;
-            this.pagePanelsClient.Margin = new System.Windows.Forms.Padding(4);
-            this.pagePanelsClient.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pagePanelsClient.MinimumSize = new System.Drawing.Size(50, 50);
             this.pagePanelsClient.Name = "pagePanelsClient";
-            this.pagePanelsClient.Size = new System.Drawing.Size(67, 615);
+            this.pagePanelsClient.Size = new System.Drawing.Size(50, 500);
             this.pagePanelsClient.Text = "Client";
             this.pagePanelsClient.TextDescription = "Client is the main style for client area of Krypton panels.";
             this.pagePanelsClient.ToolTipTitle = "Page ToolTip";
@@ -3966,10 +3752,9 @@ namespace PaletteDesigner
             this.pagePanelsAlternate.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsAlternate.ImageLarge")));
             this.pagePanelsAlternate.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsAlternate.ImageMedium")));
             this.pagePanelsAlternate.LastVisibleSet = true;
-            this.pagePanelsAlternate.Margin = new System.Windows.Forms.Padding(4);
-            this.pagePanelsAlternate.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pagePanelsAlternate.MinimumSize = new System.Drawing.Size(50, 50);
             this.pagePanelsAlternate.Name = "pagePanelsAlternate";
-            this.pagePanelsAlternate.Size = new System.Drawing.Size(67, 615);
+            this.pagePanelsAlternate.Size = new System.Drawing.Size(50, 500);
             this.pagePanelsAlternate.Text = "Alternate";
             this.pagePanelsAlternate.TextDescription = "Alternate provides a complementary variation on the Client style.";
             this.pagePanelsAlternate.ToolTipTitle = "Page ToolTip";
@@ -3980,10 +3765,9 @@ namespace PaletteDesigner
             this.pagePanelsRibbonInactive.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pagePanelsRibbonInactive.Flags = 65534;
             this.pagePanelsRibbonInactive.LastVisibleSet = true;
-            this.pagePanelsRibbonInactive.Margin = new System.Windows.Forms.Padding(4);
-            this.pagePanelsRibbonInactive.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pagePanelsRibbonInactive.MinimumSize = new System.Drawing.Size(50, 50);
             this.pagePanelsRibbonInactive.Name = "pagePanelsRibbonInactive";
-            this.pagePanelsRibbonInactive.Size = new System.Drawing.Size(133, 123);
+            this.pagePanelsRibbonInactive.Size = new System.Drawing.Size(100, 100);
             this.pagePanelsRibbonInactive.Text = "Ribbon Inactive";
             this.pagePanelsRibbonInactive.TextDescription = "Ribbon Inactive provides the ribbon background style when inside an inactive Form" +
     ".";
@@ -3997,10 +3781,9 @@ namespace PaletteDesigner
             this.pagePanelsCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsCustom1.ImageLarge")));
             this.pagePanelsCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pagePanelsCustom1.ImageMedium")));
             this.pagePanelsCustom1.LastVisibleSet = true;
-            this.pagePanelsCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pagePanelsCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pagePanelsCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pagePanelsCustom1.Name = "pagePanelsCustom1";
-            this.pagePanelsCustom1.Size = new System.Drawing.Size(67, 615);
+            this.pagePanelsCustom1.Size = new System.Drawing.Size(50, 500);
             this.pagePanelsCustom1.Text = "Custom 1";
             this.pagePanelsCustom1.TextDescription = "Custom 1 style inherits from Client and is intended for your own custom use.";
             this.pagePanelsCustom1.ToolTipTitle = "Page ToolTip";
@@ -4024,10 +3807,9 @@ namespace PaletteDesigner
             this.pageDesignRadioButton.Flags = 65535;
             this.pageDesignRadioButton.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignRadioButton.ImageSmall")));
             this.pageDesignRadioButton.LastVisibleSet = true;
-            this.pageDesignRadioButton.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignRadioButton.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignRadioButton.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignRadioButton.Name = "pageDesignRadioButton";
-            this.pageDesignRadioButton.Size = new System.Drawing.Size(585, 615);
+            this.pageDesignRadioButton.Size = new System.Drawing.Size(439, 500);
             this.pageDesignRadioButton.Text = "Design RadioButton";
             this.pageDesignRadioButton.TextDescription = "Preview appearance of the RadioButton control.";
             this.pageDesignRadioButton.TextTitle = "";
@@ -4036,39 +3818,35 @@ namespace PaletteDesigner
             // 
             // rbLive2
             // 
-            this.rbLive2.Location = new System.Drawing.Point(273, 122);
-            this.rbLive2.Margin = new System.Windows.Forms.Padding(4);
+            this.rbLive2.Location = new System.Drawing.Point(205, 99);
             this.rbLive2.Name = "rbLive2";
-            this.rbLive2.Size = new System.Drawing.Size(63, 24);
+            this.rbLive2.Size = new System.Drawing.Size(54, 20);
             this.rbLive2.TabIndex = 11;
             this.rbLive2.Values.Text = "Live 2";
             // 
             // kryptonRadioButton11
             // 
-            this.kryptonRadioButton11.Location = new System.Drawing.Point(1203, 18);
-            this.kryptonRadioButton11.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonRadioButton11.Location = new System.Drawing.Point(902, 15);
             this.kryptonRadioButton11.Name = "kryptonRadioButton11";
-            this.kryptonRadioButton11.Size = new System.Drawing.Size(32, 24);
+            this.kryptonRadioButton11.Size = new System.Drawing.Size(29, 20);
             this.kryptonRadioButton11.TabIndex = 10;
             this.kryptonRadioButton11.Values.Text = "2";
             // 
             // rbLive1
             // 
             this.rbLive1.Checked = true;
-            this.rbLive1.Location = new System.Drawing.Point(273, 75);
-            this.rbLive1.Margin = new System.Windows.Forms.Padding(4);
+            this.rbLive1.Location = new System.Drawing.Point(205, 61);
             this.rbLive1.Name = "rbLive1";
-            this.rbLive1.Size = new System.Drawing.Size(63, 24);
+            this.rbLive1.Size = new System.Drawing.Size(54, 20);
             this.rbLive1.TabIndex = 9;
             this.rbLive1.Values.Text = "Live 1";
             // 
             // rbFocus
             // 
             this.rbFocus.AutoCheck = false;
-            this.rbFocus.Location = new System.Drawing.Point(273, 28);
-            this.rbFocus.Margin = new System.Windows.Forms.Padding(4);
+            this.rbFocus.Location = new System.Drawing.Point(205, 23);
             this.rbFocus.Name = "rbFocus";
-            this.rbFocus.Size = new System.Drawing.Size(63, 24);
+            this.rbFocus.Size = new System.Drawing.Size(54, 20);
             this.rbFocus.TabIndex = 8;
             this.rbFocus.Values.Text = "Focus";
             // 
@@ -4076,10 +3854,9 @@ namespace PaletteDesigner
             // 
             this.rbCheckedTracking.AutoCheck = false;
             this.rbCheckedTracking.Checked = true;
-            this.rbCheckedTracking.Location = new System.Drawing.Point(31, 327);
-            this.rbCheckedTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.rbCheckedTracking.Location = new System.Drawing.Point(23, 266);
             this.rbCheckedTracking.Name = "rbCheckedTracking";
-            this.rbCheckedTracking.Size = new System.Drawing.Size(144, 24);
+            this.rbCheckedTracking.Size = new System.Drawing.Size(119, 20);
             this.rbCheckedTracking.TabIndex = 7;
             this.rbCheckedTracking.Values.Text = "Checked Tracking";
             // 
@@ -4087,10 +3864,9 @@ namespace PaletteDesigner
             // 
             this.rbCheckedPressed.AutoCheck = false;
             this.rbCheckedPressed.Checked = true;
-            this.rbCheckedPressed.Location = new System.Drawing.Point(31, 374);
-            this.rbCheckedPressed.Margin = new System.Windows.Forms.Padding(4);
+            this.rbCheckedPressed.Location = new System.Drawing.Point(23, 304);
             this.rbCheckedPressed.Name = "rbCheckedPressed";
-            this.rbCheckedPressed.Size = new System.Drawing.Size(138, 24);
+            this.rbCheckedPressed.Size = new System.Drawing.Size(114, 20);
             this.rbCheckedPressed.TabIndex = 6;
             this.rbCheckedPressed.Values.Text = "Checked Pressed";
             // 
@@ -4098,10 +3874,9 @@ namespace PaletteDesigner
             // 
             this.rbCheckedNormal.AutoCheck = false;
             this.rbCheckedNormal.Checked = true;
-            this.rbCheckedNormal.Location = new System.Drawing.Point(31, 281);
-            this.rbCheckedNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.rbCheckedNormal.Location = new System.Drawing.Point(23, 228);
             this.rbCheckedNormal.Name = "rbCheckedNormal";
-            this.rbCheckedNormal.Size = new System.Drawing.Size(137, 24);
+            this.rbCheckedNormal.Size = new System.Drawing.Size(113, 20);
             this.rbCheckedNormal.TabIndex = 5;
             this.rbCheckedNormal.Values.Text = "Checked Normal";
             // 
@@ -4109,50 +3884,45 @@ namespace PaletteDesigner
             // 
             this.rbCheckedDisabled.AutoCheck = false;
             this.rbCheckedDisabled.Checked = true;
-            this.rbCheckedDisabled.Location = new System.Drawing.Point(31, 234);
-            this.rbCheckedDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.rbCheckedDisabled.Location = new System.Drawing.Point(23, 190);
             this.rbCheckedDisabled.Name = "rbCheckedDisabled";
-            this.rbCheckedDisabled.Size = new System.Drawing.Size(145, 24);
+            this.rbCheckedDisabled.Size = new System.Drawing.Size(120, 20);
             this.rbCheckedDisabled.TabIndex = 4;
             this.rbCheckedDisabled.Values.Text = "Checked Disabled";
             // 
             // rbUncheckedTracking
             // 
             this.rbUncheckedTracking.AutoCheck = false;
-            this.rbUncheckedTracking.Location = new System.Drawing.Point(31, 122);
-            this.rbUncheckedTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.rbUncheckedTracking.Location = new System.Drawing.Point(23, 99);
             this.rbUncheckedTracking.Name = "rbUncheckedTracking";
-            this.rbUncheckedTracking.Size = new System.Drawing.Size(161, 24);
+            this.rbUncheckedTracking.Size = new System.Drawing.Size(132, 20);
             this.rbUncheckedTracking.TabIndex = 3;
             this.rbUncheckedTracking.Values.Text = "Unchecked Tracking";
             // 
             // rbUncheckedPressed
             // 
             this.rbUncheckedPressed.AutoCheck = false;
-            this.rbUncheckedPressed.Location = new System.Drawing.Point(31, 169);
-            this.rbUncheckedPressed.Margin = new System.Windows.Forms.Padding(4);
+            this.rbUncheckedPressed.Location = new System.Drawing.Point(23, 137);
             this.rbUncheckedPressed.Name = "rbUncheckedPressed";
-            this.rbUncheckedPressed.Size = new System.Drawing.Size(155, 24);
+            this.rbUncheckedPressed.Size = new System.Drawing.Size(128, 20);
             this.rbUncheckedPressed.TabIndex = 2;
             this.rbUncheckedPressed.Values.Text = "Unchecked Pressed";
             // 
             // rbUncheckedNormal
             // 
             this.rbUncheckedNormal.AutoCheck = false;
-            this.rbUncheckedNormal.Location = new System.Drawing.Point(31, 75);
-            this.rbUncheckedNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.rbUncheckedNormal.Location = new System.Drawing.Point(23, 61);
             this.rbUncheckedNormal.Name = "rbUncheckedNormal";
-            this.rbUncheckedNormal.Size = new System.Drawing.Size(154, 24);
+            this.rbUncheckedNormal.Size = new System.Drawing.Size(127, 20);
             this.rbUncheckedNormal.TabIndex = 1;
             this.rbUncheckedNormal.Values.Text = "Unchecked Normal";
             // 
             // rbUncheckedDisabled
             // 
             this.rbUncheckedDisabled.AutoCheck = false;
-            this.rbUncheckedDisabled.Location = new System.Drawing.Point(31, 28);
-            this.rbUncheckedDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.rbUncheckedDisabled.Location = new System.Drawing.Point(23, 23);
             this.rbUncheckedDisabled.Name = "rbUncheckedDisabled";
-            this.rbUncheckedDisabled.Size = new System.Drawing.Size(162, 24);
+            this.rbUncheckedDisabled.Size = new System.Drawing.Size(133, 20);
             this.rbUncheckedDisabled.TabIndex = 0;
             this.rbUncheckedDisabled.Values.Text = "Unchecked Disabled";
             // 
@@ -4176,10 +3946,9 @@ namespace PaletteDesigner
             this.pageDesignSeparators.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignSeparators.ImageMedium")));
             this.pageDesignSeparators.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignSeparators.ImageSmall")));
             this.pageDesignSeparators.LastVisibleSet = true;
-            this.pageDesignSeparators.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignSeparators.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignSeparators.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignSeparators.Name = "pageDesignSeparators";
-            this.pageDesignSeparators.Size = new System.Drawing.Size(585, 615);
+            this.pageDesignSeparators.Size = new System.Drawing.Size(439, 500);
             this.pageDesignSeparators.Text = "Design Separators";
             this.pageDesignSeparators.TextDescription = "Low Profile style is a low visibility display of a separator.";
             this.pageDesignSeparators.TextTitle = "Low Profile";
@@ -4189,9 +3958,7 @@ namespace PaletteDesigner
             // separator1Live
             // 
             this.separator1Live.Cursor = System.Windows.Forms.Cursors.Default;
-            this.separator1Live.Location = new System.Drawing.Point(268, 409);
-            this.separator1Live.Margin = new System.Windows.Forms.Padding(4);
-            this.separator1Live.Name = "separator1Live";
+            this.separator1Live.Location = new System.Drawing.Point(201, 332);
             this.separator1Live.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // separator1Live.Panel1
@@ -4201,26 +3968,22 @@ namespace PaletteDesigner
             // separator1Live.Panel2
             // 
             this.separator1Live.Panel2.Controls.Add(this.kryptonGroup12);
-            this.separator1Live.Size = new System.Drawing.Size(133, 98);
-            this.separator1Live.SplitterDistance = 41;
+            this.separator1Live.Size = new System.Drawing.Size(100, 80);
+            this.separator1Live.SplitterDistance = 33;
             this.separator1Live.TabIndex = 24;
             // 
             // kryptonGroup11
             // 
             this.kryptonGroup11.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup11.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup11.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup11.Name = "kryptonGroup11";
-            this.kryptonGroup11.Size = new System.Drawing.Size(133, 41);
+            this.kryptonGroup11.Size = new System.Drawing.Size(100, 33);
             this.kryptonGroup11.TabIndex = 0;
             // 
             // kryptonGroup12
             // 
             this.kryptonGroup12.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup12.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup12.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup12.Name = "kryptonGroup12";
-            this.kryptonGroup12.Size = new System.Drawing.Size(133, 52);
+            this.kryptonGroup12.Size = new System.Drawing.Size(100, 42);
             this.kryptonGroup12.TabIndex = 0;
             // 
             // labelSeparatorsLive
@@ -4229,10 +3992,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelSeparatorsLive.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelSeparatorsLive.Location = new System.Drawing.Point(279, 370);
-            this.labelSeparatorsLive.Margin = new System.Windows.Forms.Padding(4);
+            this.labelSeparatorsLive.Location = new System.Drawing.Point(209, 301);
             this.labelSeparatorsLive.Name = "labelSeparatorsLive";
-            this.labelSeparatorsLive.Size = new System.Drawing.Size(108, 35);
+            this.labelSeparatorsLive.Size = new System.Drawing.Size(88, 29);
             this.labelSeparatorsLive.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelSeparatorsLive.TabIndex = 25;
             this.labelSeparatorsLive.Values.Text = "Tracking";
@@ -4240,9 +4002,7 @@ namespace PaletteDesigner
             // separator1Pressed
             // 
             this.separator1Pressed.Cursor = System.Windows.Forms.Cursors.Default;
-            this.separator1Pressed.Location = new System.Drawing.Point(379, 238);
-            this.separator1Pressed.Margin = new System.Windows.Forms.Padding(4);
-            this.separator1Pressed.Name = "separator1Pressed";
+            this.separator1Pressed.Location = new System.Drawing.Point(284, 193);
             this.separator1Pressed.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // separator1Pressed.Panel1
@@ -4252,34 +4012,28 @@ namespace PaletteDesigner
             // separator1Pressed.Panel2
             // 
             this.separator1Pressed.Panel2.Controls.Add(this.kryptonGroup8);
-            this.separator1Pressed.Size = new System.Drawing.Size(133, 98);
-            this.separator1Pressed.SplitterDistance = 41;
+            this.separator1Pressed.Size = new System.Drawing.Size(100, 80);
+            this.separator1Pressed.SplitterDistance = 33;
             this.separator1Pressed.TabIndex = 22;
             // 
             // kryptonGroup7
             // 
             this.kryptonGroup7.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup7.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup7.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup7.Name = "kryptonGroup7";
-            this.kryptonGroup7.Size = new System.Drawing.Size(133, 41);
+            this.kryptonGroup7.Size = new System.Drawing.Size(100, 33);
             this.kryptonGroup7.TabIndex = 0;
             // 
             // kryptonGroup8
             // 
             this.kryptonGroup8.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup8.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup8.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup8.Name = "kryptonGroup8";
-            this.kryptonGroup8.Size = new System.Drawing.Size(133, 52);
+            this.kryptonGroup8.Size = new System.Drawing.Size(100, 42);
             this.kryptonGroup8.TabIndex = 0;
             // 
             // separator1Tracking
             // 
             this.separator1Tracking.Cursor = System.Windows.Forms.Cursors.Default;
-            this.separator1Tracking.Location = new System.Drawing.Point(160, 238);
-            this.separator1Tracking.Margin = new System.Windows.Forms.Padding(4);
-            this.separator1Tracking.Name = "separator1Tracking";
+            this.separator1Tracking.Location = new System.Drawing.Point(120, 193);
             this.separator1Tracking.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // separator1Tracking.Panel1
@@ -4289,26 +4043,22 @@ namespace PaletteDesigner
             // separator1Tracking.Panel2
             // 
             this.separator1Tracking.Panel2.Controls.Add(this.kryptonGroup6);
-            this.separator1Tracking.Size = new System.Drawing.Size(133, 98);
-            this.separator1Tracking.SplitterDistance = 41;
+            this.separator1Tracking.Size = new System.Drawing.Size(100, 80);
+            this.separator1Tracking.SplitterDistance = 33;
             this.separator1Tracking.TabIndex = 21;
             // 
             // kryptonGroup5
             // 
             this.kryptonGroup5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup5.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup5.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup5.Name = "kryptonGroup5";
-            this.kryptonGroup5.Size = new System.Drawing.Size(133, 41);
+            this.kryptonGroup5.Size = new System.Drawing.Size(100, 33);
             this.kryptonGroup5.TabIndex = 0;
             // 
             // kryptonGroup6
             // 
             this.kryptonGroup6.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup6.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup6.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup6.Name = "kryptonGroup6";
-            this.kryptonGroup6.Size = new System.Drawing.Size(133, 52);
+            this.kryptonGroup6.Size = new System.Drawing.Size(100, 42);
             this.kryptonGroup6.TabIndex = 0;
             // 
             // labelSeparatorsPressed
@@ -4317,10 +4067,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelSeparatorsPressed.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelSeparatorsPressed.Location = new System.Drawing.Point(393, 199);
-            this.labelSeparatorsPressed.Margin = new System.Windows.Forms.Padding(4);
+            this.labelSeparatorsPressed.Location = new System.Drawing.Point(295, 162);
             this.labelSeparatorsPressed.Name = "labelSeparatorsPressed";
-            this.labelSeparatorsPressed.Size = new System.Drawing.Size(97, 35);
+            this.labelSeparatorsPressed.Size = new System.Drawing.Size(79, 29);
             this.labelSeparatorsPressed.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelSeparatorsPressed.TabIndex = 26;
             this.labelSeparatorsPressed.Values.Text = "Pressed";
@@ -4331,10 +4080,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelSeparatorsTracking.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelSeparatorsTracking.Location = new System.Drawing.Point(173, 199);
-            this.labelSeparatorsTracking.Margin = new System.Windows.Forms.Padding(4);
+            this.labelSeparatorsTracking.Location = new System.Drawing.Point(130, 162);
             this.labelSeparatorsTracking.Name = "labelSeparatorsTracking";
-            this.labelSeparatorsTracking.Size = new System.Drawing.Size(108, 35);
+            this.labelSeparatorsTracking.Size = new System.Drawing.Size(88, 29);
             this.labelSeparatorsTracking.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelSeparatorsTracking.TabIndex = 27;
             this.labelSeparatorsTracking.Values.Text = "Tracking";
@@ -4342,9 +4090,7 @@ namespace PaletteDesigner
             // separator1Normal
             // 
             this.separator1Normal.Cursor = System.Windows.Forms.Cursors.Default;
-            this.separator1Normal.Location = new System.Drawing.Point(377, 76);
-            this.separator1Normal.Margin = new System.Windows.Forms.Padding(4);
-            this.separator1Normal.Name = "separator1Normal";
+            this.separator1Normal.Location = new System.Drawing.Point(283, 62);
             this.separator1Normal.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // separator1Normal.Panel1
@@ -4354,35 +4100,29 @@ namespace PaletteDesigner
             // separator1Normal.Panel2
             // 
             this.separator1Normal.Panel2.Controls.Add(this.kryptonGroup4);
-            this.separator1Normal.Size = new System.Drawing.Size(133, 98);
-            this.separator1Normal.SplitterDistance = 40;
+            this.separator1Normal.Size = new System.Drawing.Size(100, 80);
+            this.separator1Normal.SplitterDistance = 32;
             this.separator1Normal.TabIndex = 18;
             // 
             // kryptonGroup3
             // 
             this.kryptonGroup3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup3.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup3.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup3.Name = "kryptonGroup3";
-            this.kryptonGroup3.Size = new System.Drawing.Size(133, 40);
+            this.kryptonGroup3.Size = new System.Drawing.Size(100, 32);
             this.kryptonGroup3.TabIndex = 0;
             // 
             // kryptonGroup4
             // 
             this.kryptonGroup4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup4.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup4.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup4.Name = "kryptonGroup4";
-            this.kryptonGroup4.Size = new System.Drawing.Size(133, 53);
+            this.kryptonGroup4.Size = new System.Drawing.Size(100, 43);
             this.kryptonGroup4.TabIndex = 0;
             // 
             // separator1Disabled
             // 
             this.separator1Disabled.Cursor = System.Windows.Forms.Cursors.Default;
             this.separator1Disabled.Enabled = false;
-            this.separator1Disabled.Location = new System.Drawing.Point(159, 76);
-            this.separator1Disabled.Margin = new System.Windows.Forms.Padding(4);
-            this.separator1Disabled.Name = "separator1Disabled";
+            this.separator1Disabled.Location = new System.Drawing.Point(119, 62);
             this.separator1Disabled.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // separator1Disabled.Panel1
@@ -4392,26 +4132,22 @@ namespace PaletteDesigner
             // separator1Disabled.Panel2
             // 
             this.separator1Disabled.Panel2.Controls.Add(this.kryptonGroup2);
-            this.separator1Disabled.Size = new System.Drawing.Size(133, 98);
-            this.separator1Disabled.SplitterDistance = 41;
+            this.separator1Disabled.Size = new System.Drawing.Size(100, 80);
+            this.separator1Disabled.SplitterDistance = 33;
             this.separator1Disabled.TabIndex = 15;
             // 
             // kryptonGroup1
             // 
             this.kryptonGroup1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup1.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup1.Name = "kryptonGroup1";
-            this.kryptonGroup1.Size = new System.Drawing.Size(133, 41);
+            this.kryptonGroup1.Size = new System.Drawing.Size(100, 33);
             this.kryptonGroup1.TabIndex = 0;
             // 
             // kryptonGroup2
             // 
             this.kryptonGroup2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup2.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup2.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonGroup2.Name = "kryptonGroup2";
-            this.kryptonGroup2.Size = new System.Drawing.Size(133, 52);
+            this.kryptonGroup2.Size = new System.Drawing.Size(100, 42);
             this.kryptonGroup2.TabIndex = 0;
             // 
             // labelSeparatorsNormal
@@ -4420,10 +4156,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelSeparatorsNormal.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelSeparatorsNormal.Location = new System.Drawing.Point(397, 37);
-            this.labelSeparatorsNormal.Margin = new System.Windows.Forms.Padding(4);
+            this.labelSeparatorsNormal.Location = new System.Drawing.Point(298, 30);
             this.labelSeparatorsNormal.Name = "labelSeparatorsNormal";
-            this.labelSeparatorsNormal.Size = new System.Drawing.Size(96, 35);
+            this.labelSeparatorsNormal.Size = new System.Drawing.Size(78, 29);
             this.labelSeparatorsNormal.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelSeparatorsNormal.TabIndex = 28;
             this.labelSeparatorsNormal.Values.Text = "Normal";
@@ -4434,10 +4169,9 @@ namespace PaletteDesigner
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelSeparatorsDisabled.LabelStyle = Krypton.Toolkit.LabelStyle.TitleControl;
-            this.labelSeparatorsDisabled.Location = new System.Drawing.Point(172, 37);
-            this.labelSeparatorsDisabled.Margin = new System.Windows.Forms.Padding(4);
+            this.labelSeparatorsDisabled.Location = new System.Drawing.Point(129, 30);
             this.labelSeparatorsDisabled.Name = "labelSeparatorsDisabled";
-            this.labelSeparatorsDisabled.Size = new System.Drawing.Size(108, 35);
+            this.labelSeparatorsDisabled.Size = new System.Drawing.Size(88, 29);
             this.labelSeparatorsDisabled.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.labelSeparatorsDisabled.TabIndex = 29;
             this.labelSeparatorsDisabled.Values.Text = "Disabled";
@@ -4445,11 +4179,10 @@ namespace PaletteDesigner
             // borderDesignSeparators
             // 
             this.borderDesignSeparators.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignSeparators.Location = new System.Drawing.Point(108, 0);
-            this.borderDesignSeparators.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignSeparators.Location = new System.Drawing.Point(89, 0);
             this.borderDesignSeparators.Name = "borderDesignSeparators";
             this.borderDesignSeparators.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignSeparators.Size = new System.Drawing.Size(1, 615);
+            this.borderDesignSeparators.Size = new System.Drawing.Size(1, 500);
             this.borderDesignSeparators.TabIndex = 4;
             // 
             // kryptonNavigatorDesignSeparators
@@ -4482,8 +4215,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignSeparators.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignSeparators.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignSeparators.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignSeparators.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignSeparators.Name = "kryptonNavigatorDesignSeparators";
             this.kryptonNavigatorDesignSeparators.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignSeparators.Owner = null;
             this.kryptonNavigatorDesignSeparators.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -4494,7 +4225,7 @@ namespace PaletteDesigner
             this.pageSeparatorCustom1});
             this.kryptonNavigatorDesignSeparators.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignSeparators.SelectedIndex = 0;
-            this.kryptonNavigatorDesignSeparators.Size = new System.Drawing.Size(108, 615);
+            this.kryptonNavigatorDesignSeparators.Size = new System.Drawing.Size(89, 500);
             this.kryptonNavigatorDesignSeparators.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignSeparators.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignSeparators.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -4511,10 +4242,9 @@ namespace PaletteDesigner
             this.pageSeparatorLowProfile.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorLowProfile.ImageLarge")));
             this.pageSeparatorLowProfile.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorLowProfile.ImageMedium")));
             this.pageSeparatorLowProfile.LastVisibleSet = true;
-            this.pageSeparatorLowProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageSeparatorLowProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageSeparatorLowProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageSeparatorLowProfile.Name = "pageSeparatorLowProfile";
-            this.pageSeparatorLowProfile.Size = new System.Drawing.Size(67, 615);
+            this.pageSeparatorLowProfile.Size = new System.Drawing.Size(50, 500);
             this.pageSeparatorLowProfile.Text = "Low";
             this.pageSeparatorLowProfile.TextDescription = "Low Profile style is a low visibility display of a separator.";
             this.pageSeparatorLowProfile.ToolTipTitle = "Page ToolTip";
@@ -4527,10 +4257,9 @@ namespace PaletteDesigner
             this.pageSeparatorHighProfile.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorHighProfile.ImageLarge")));
             this.pageSeparatorHighProfile.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorHighProfile.ImageMedium")));
             this.pageSeparatorHighProfile.LastVisibleSet = true;
-            this.pageSeparatorHighProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageSeparatorHighProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageSeparatorHighProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageSeparatorHighProfile.Name = "pageSeparatorHighProfile";
-            this.pageSeparatorHighProfile.Size = new System.Drawing.Size(67, 615);
+            this.pageSeparatorHighProfile.Size = new System.Drawing.Size(50, 500);
             this.pageSeparatorHighProfile.Text = "High";
             this.pageSeparatorHighProfile.TextDescription = "High Profile style is a high visibility display of a separator.";
             this.pageSeparatorHighProfile.ToolTipTitle = "Page ToolTip";
@@ -4541,10 +4270,9 @@ namespace PaletteDesigner
             this.pageSeparatorHighInternalProfile.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageSeparatorHighInternalProfile.Flags = 65535;
             this.pageSeparatorHighInternalProfile.LastVisibleSet = true;
-            this.pageSeparatorHighInternalProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageSeparatorHighInternalProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageSeparatorHighInternalProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageSeparatorHighInternalProfile.Name = "pageSeparatorHighInternalProfile";
-            this.pageSeparatorHighInternalProfile.Size = new System.Drawing.Size(133, 123);
+            this.pageSeparatorHighInternalProfile.Size = new System.Drawing.Size(100, 100);
             this.pageSeparatorHighInternalProfile.Text = "High Internal";
             this.pageSeparatorHighInternalProfile.TextDescription = "High Internal Profile style is a high visibility display of an internal  separato" +
     "r.";
@@ -4558,10 +4286,9 @@ namespace PaletteDesigner
             this.pageSeparatorCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorCustom1.ImageLarge")));
             this.pageSeparatorCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageSeparatorCustom1.ImageMedium")));
             this.pageSeparatorCustom1.LastVisibleSet = true;
-            this.pageSeparatorCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pageSeparatorCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageSeparatorCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageSeparatorCustom1.Name = "pageSeparatorCustom1";
-            this.pageSeparatorCustom1.Size = new System.Drawing.Size(67, 615);
+            this.pageSeparatorCustom1.Size = new System.Drawing.Size(50, 500);
             this.pageSeparatorCustom1.Text = "Custom 1";
             this.pageSeparatorCustom1.TextDescription = "Custom 1 style inherits from Low Profile and is intended for your own custom use." +
     "";
@@ -4579,10 +4306,9 @@ namespace PaletteDesigner
             this.pageDesignTabs.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignTabs.ImageMedium")));
             this.pageDesignTabs.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("pageDesignTabs.ImageSmall")));
             this.pageDesignTabs.LastVisibleSet = true;
-            this.pageDesignTabs.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignTabs.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignTabs.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignTabs.Name = "pageDesignTabs";
-            this.pageDesignTabs.Size = new System.Drawing.Size(616, 645);
+            this.pageDesignTabs.Size = new System.Drawing.Size(462, 524);
             this.pageDesignTabs.Text = "Design Tabs";
             this.pageDesignTabs.TextDescription = "High Profile is appropriate when the selected page needs to stand out.";
             this.pageDesignTabs.TextTitle = "High Profile";
@@ -4603,9 +4329,7 @@ namespace PaletteDesigner
             this.kryptonNavigatorTabs.Button.PreviousButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
             this.kryptonNavigatorTabs.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
             this.kryptonNavigatorTabs.ControlKryptonFormFeatures = false;
-            this.kryptonNavigatorTabs.Location = new System.Drawing.Point(188, 39);
-            this.kryptonNavigatorTabs.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorTabs.Name = "kryptonNavigatorTabs";
+            this.kryptonNavigatorTabs.Location = new System.Drawing.Point(141, 32);
             this.kryptonNavigatorTabs.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
             this.kryptonNavigatorTabs.Owner = null;
             this.kryptonNavigatorTabs.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -4626,10 +4350,9 @@ namespace PaletteDesigner
             this.kryptonNavigatorTabs1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonNavigatorTabs1.ImageMedium")));
             this.kryptonNavigatorTabs1.ImageSmall = global::PaletteDesigner.Properties.Resources.environment;
             this.kryptonNavigatorTabs1.LastVisibleSet = true;
-            this.kryptonNavigatorTabs1.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorTabs1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonNavigatorTabs1.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonNavigatorTabs1.Name = "kryptonNavigatorTabs1";
-            this.kryptonNavigatorTabs1.Size = new System.Drawing.Size(283, 119);
+            this.kryptonNavigatorTabs1.Size = new System.Drawing.Size(283, 123);
             this.kryptonNavigatorTabs1.Text = "Page 1";
             this.kryptonNavigatorTabs1.ToolTipTitle = "Page ToolTip";
             this.kryptonNavigatorTabs1.UniqueName = "E903D110CD804DC4E903D110CD804DC4";
@@ -4642,10 +4365,9 @@ namespace PaletteDesigner
             this.kryptonNavigatorTabs2.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonNavigatorTabs2.ImageMedium")));
             this.kryptonNavigatorTabs2.ImageSmall = global::PaletteDesigner.Properties.Resources.document_new;
             this.kryptonNavigatorTabs2.LastVisibleSet = true;
-            this.kryptonNavigatorTabs2.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorTabs2.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonNavigatorTabs2.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonNavigatorTabs2.Name = "kryptonNavigatorTabs2";
-            this.kryptonNavigatorTabs2.Size = new System.Drawing.Size(133, 123);
+            this.kryptonNavigatorTabs2.Size = new System.Drawing.Size(100, 100);
             this.kryptonNavigatorTabs2.Text = "Page 2";
             this.kryptonNavigatorTabs2.ToolTipTitle = "Page ToolTip";
             this.kryptonNavigatorTabs2.UniqueName = "49A9A449D97C4EBF49A9A449D97C4EBF";
@@ -4658,10 +4380,9 @@ namespace PaletteDesigner
             this.kryptonNavigatorTabs3.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("kryptonNavigatorTabs3.ImageMedium")));
             this.kryptonNavigatorTabs3.ImageSmall = ((System.Drawing.Bitmap)(resources.GetObject("kryptonNavigatorTabs3.ImageSmall")));
             this.kryptonNavigatorTabs3.LastVisibleSet = true;
-            this.kryptonNavigatorTabs3.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorTabs3.MinimumSize = new System.Drawing.Size(67, 62);
+            this.kryptonNavigatorTabs3.MinimumSize = new System.Drawing.Size(50, 50);
             this.kryptonNavigatorTabs3.Name = "kryptonNavigatorTabs3";
-            this.kryptonNavigatorTabs3.Size = new System.Drawing.Size(133, 123);
+            this.kryptonNavigatorTabs3.Size = new System.Drawing.Size(100, 100);
             this.kryptonNavigatorTabs3.Text = "Page 3";
             this.kryptonNavigatorTabs3.ToolTipTitle = "Page ToolTip";
             this.kryptonNavigatorTabs3.UniqueName = "ECD1F28E6CB04389ECD1F28E6CB04389";
@@ -4669,11 +4390,10 @@ namespace PaletteDesigner
             // borderDesignTabs
             // 
             this.borderDesignTabs.Dock = System.Windows.Forms.DockStyle.Left;
-            this.borderDesignTabs.Location = new System.Drawing.Point(141, 0);
-            this.borderDesignTabs.Margin = new System.Windows.Forms.Padding(4);
+            this.borderDesignTabs.Location = new System.Drawing.Point(116, 0);
             this.borderDesignTabs.Name = "borderDesignTabs";
             this.borderDesignTabs.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.HeaderPrimary;
-            this.borderDesignTabs.Size = new System.Drawing.Size(1, 645);
+            this.borderDesignTabs.Size = new System.Drawing.Size(1, 524);
             this.borderDesignTabs.TabIndex = 3;
             // 
             // kryptonNavigatorDesignTabs
@@ -4707,8 +4427,6 @@ namespace PaletteDesigner
             this.kryptonNavigatorDesignTabs.ControlKryptonFormFeatures = false;
             this.kryptonNavigatorDesignTabs.Dock = System.Windows.Forms.DockStyle.Left;
             this.kryptonNavigatorDesignTabs.Location = new System.Drawing.Point(0, 0);
-            this.kryptonNavigatorDesignTabs.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonNavigatorDesignTabs.Name = "kryptonNavigatorDesignTabs";
             this.kryptonNavigatorDesignTabs.NavigatorMode = Krypton.Navigator.NavigatorMode.BarCheckButtonOnly;
             this.kryptonNavigatorDesignTabs.Owner = null;
             this.kryptonNavigatorDesignTabs.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlAlternate;
@@ -4724,7 +4442,7 @@ namespace PaletteDesigner
             this.pageTabCustom3});
             this.kryptonNavigatorDesignTabs.Panel.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonNavigatorDesignTabs.SelectedIndex = 0;
-            this.kryptonNavigatorDesignTabs.Size = new System.Drawing.Size(141, 645);
+            this.kryptonNavigatorDesignTabs.Size = new System.Drawing.Size(116, 524);
             this.kryptonNavigatorDesignTabs.StateCommon.Bar.BarPaddingInside = new System.Windows.Forms.Padding(-1);
             this.kryptonNavigatorDesignTabs.StateCommon.Bar.BarPaddingOnly = new System.Windows.Forms.Padding(5);
             this.kryptonNavigatorDesignTabs.StateCommon.Bar.BarPaddingOutside = new System.Windows.Forms.Padding(-1);
@@ -4741,10 +4459,9 @@ namespace PaletteDesigner
             this.pageTabHighProfile.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabHighProfile.ImageLarge")));
             this.pageTabHighProfile.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabHighProfile.ImageMedium")));
             this.pageTabHighProfile.LastVisibleSet = true;
-            this.pageTabHighProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabHighProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabHighProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabHighProfile.Name = "pageTabHighProfile";
-            this.pageTabHighProfile.Size = new System.Drawing.Size(197, 90);
+            this.pageTabHighProfile.Size = new System.Drawing.Size(148, 73);
             this.pageTabHighProfile.Text = "High Profile";
             this.pageTabHighProfile.TextDescription = "High Profile is appropriate when the selected page needs to stand out.";
             this.pageTabHighProfile.ToolTipTitle = "Page ToolTip";
@@ -4757,10 +4474,9 @@ namespace PaletteDesigner
             this.pageTabStandardProfile.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabStandardProfile.ImageLarge")));
             this.pageTabStandardProfile.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabStandardProfile.ImageMedium")));
             this.pageTabStandardProfile.LastVisibleSet = true;
-            this.pageTabStandardProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabStandardProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabStandardProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabStandardProfile.Name = "pageTabStandardProfile";
-            this.pageTabStandardProfile.Size = new System.Drawing.Size(133, 123);
+            this.pageTabStandardProfile.Size = new System.Drawing.Size(100, 100);
             this.pageTabStandardProfile.Text = "Standard Profile";
             this.pageTabStandardProfile.TextDescription = "Standard Profile is appropriate for most scenarios.";
             this.pageTabStandardProfile.ToolTipTitle = "Page ToolTip";
@@ -4773,10 +4489,9 @@ namespace PaletteDesigner
             this.pageTabLowProfile.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabLowProfile.ImageLarge")));
             this.pageTabLowProfile.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabLowProfile.ImageMedium")));
             this.pageTabLowProfile.LastVisibleSet = true;
-            this.pageTabLowProfile.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabLowProfile.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabLowProfile.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabLowProfile.Name = "pageTabLowProfile";
-            this.pageTabLowProfile.Size = new System.Drawing.Size(133, 123);
+            this.pageTabLowProfile.Size = new System.Drawing.Size(100, 100);
             this.pageTabLowProfile.Text = "Low Profile";
             this.pageTabLowProfile.TextDescription = "Low Profile is appropriate when only the selected page should be obvious.";
             this.pageTabLowProfile.ToolTipTitle = "Page ToolTip";
@@ -4789,10 +4504,9 @@ namespace PaletteDesigner
             this.pageTabOneNote.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabOneNote.ImageLarge")));
             this.pageTabOneNote.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabOneNote.ImageMedium")));
             this.pageTabOneNote.LastVisibleSet = true;
-            this.pageTabOneNote.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabOneNote.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabOneNote.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabOneNote.Name = "pageTabOneNote";
-            this.pageTabOneNote.Size = new System.Drawing.Size(133, 123);
+            this.pageTabOneNote.Size = new System.Drawing.Size(100, 100);
             this.pageTabOneNote.Text = "OneNote";
             this.pageTabOneNote.TextDescription = "OneNote is intended to mimic Microsoft OneNote appearance.";
             this.pageTabOneNote.ToolTipTitle = "Page ToolTip";
@@ -4803,10 +4517,9 @@ namespace PaletteDesigner
             this.pageTabDock.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageTabDock.Flags = 65535;
             this.pageTabDock.LastVisibleSet = true;
-            this.pageTabDock.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabDock.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabDock.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabDock.Name = "pageTabDock";
-            this.pageTabDock.Size = new System.Drawing.Size(133, 123);
+            this.pageTabDock.Size = new System.Drawing.Size(100, 100);
             this.pageTabDock.Text = "Dock";
             this.pageTabDock.ToolTipTitle = "Page ToolTip";
             this.pageTabDock.UniqueName = "560DFB2C3B88492C560DFB2C3B88492C";
@@ -4816,10 +4529,9 @@ namespace PaletteDesigner
             this.pageTabDockAutoHidden.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.pageTabDockAutoHidden.Flags = 65535;
             this.pageTabDockAutoHidden.LastVisibleSet = true;
-            this.pageTabDockAutoHidden.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabDockAutoHidden.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabDockAutoHidden.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabDockAutoHidden.Name = "pageTabDockAutoHidden";
-            this.pageTabDockAutoHidden.Size = new System.Drawing.Size(133, 123);
+            this.pageTabDockAutoHidden.Size = new System.Drawing.Size(100, 100);
             this.pageTabDockAutoHidden.Text = "Dock AutoHidden";
             this.pageTabDockAutoHidden.ToolTipTitle = "Page ToolTip";
             this.pageTabDockAutoHidden.UniqueName = "028B6F04D305460D028B6F04D305460D";
@@ -4831,10 +4543,9 @@ namespace PaletteDesigner
             this.pageTabCustom1.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom1.ImageLarge")));
             this.pageTabCustom1.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom1.ImageMedium")));
             this.pageTabCustom1.LastVisibleSet = true;
-            this.pageTabCustom1.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabCustom1.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabCustom1.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabCustom1.Name = "pageTabCustom1";
-            this.pageTabCustom1.Size = new System.Drawing.Size(133, 123);
+            this.pageTabCustom1.Size = new System.Drawing.Size(100, 100);
             this.pageTabCustom1.Text = "Custom 1";
             this.pageTabCustom1.TextDescription = "Custom 1 style inherits from High Profile and is intended for your own custom use" +
     ".";
@@ -4848,10 +4559,9 @@ namespace PaletteDesigner
             this.pageTabCustom2.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom2.ImageLarge")));
             this.pageTabCustom2.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom2.ImageMedium")));
             this.pageTabCustom2.LastVisibleSet = true;
-            this.pageTabCustom2.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabCustom2.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabCustom2.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabCustom2.Name = "pageTabCustom2";
-            this.pageTabCustom2.Size = new System.Drawing.Size(133, 123);
+            this.pageTabCustom2.Size = new System.Drawing.Size(100, 100);
             this.pageTabCustom2.Text = "Custom 2";
             this.pageTabCustom2.TextDescription = "Custom 2 style inherits from High Profile and is intended for your own custom use" +
     ".";
@@ -4865,10 +4575,9 @@ namespace PaletteDesigner
             this.pageTabCustom3.ImageLarge = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom3.ImageLarge")));
             this.pageTabCustom3.ImageMedium = ((System.Drawing.Bitmap)(resources.GetObject("pageTabCustom3.ImageMedium")));
             this.pageTabCustom3.LastVisibleSet = true;
-            this.pageTabCustom3.Margin = new System.Windows.Forms.Padding(4);
-            this.pageTabCustom3.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageTabCustom3.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageTabCustom3.Name = "pageTabCustom3";
-            this.pageTabCustom3.Size = new System.Drawing.Size(133, 123);
+            this.pageTabCustom3.Size = new System.Drawing.Size(100, 100);
             this.pageTabCustom3.Text = "Custom 3";
             this.pageTabCustom3.TextDescription = "Custom 3 style inherits from High Profile and is intended for your own custom use" +
     ".";
@@ -4882,10 +4591,9 @@ namespace PaletteDesigner
             this.pageDesignTrackBar.Flags = 65534;
             this.pageDesignTrackBar.ImageSmall = global::PaletteDesigner.Properties.Resources.KryptonTrackBar;
             this.pageDesignTrackBar.LastVisibleSet = true;
-            this.pageDesignTrackBar.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignTrackBar.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignTrackBar.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignTrackBar.Name = "pageDesignTrackBar";
-            this.pageDesignTrackBar.Size = new System.Drawing.Size(859, 672);
+            this.pageDesignTrackBar.Size = new System.Drawing.Size(644, 546);
             this.pageDesignTrackBar.Text = "Design TrackBar";
             this.pageDesignTrackBar.TextDescription = "TrackBar appearance in vertical and horizontal settings.";
             this.pageDesignTrackBar.TextTitle = "TrackBar";
@@ -4896,9 +4604,9 @@ namespace PaletteDesigner
             // 
             this.trackBar1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.trackBar1.Location = new System.Drawing.Point(0, 0);
-            this.trackBar1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.trackBar1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.trackBar1.Name = "trackBar1";
-            this.trackBar1.Size = new System.Drawing.Size(859, 672);
+            this.trackBar1.Size = new System.Drawing.Size(644, 546);
             this.trackBar1.TabIndex = 0;
             // 
             // pageDesignMenuItems
@@ -4907,10 +4615,10 @@ namespace PaletteDesigner
             this.pageDesignMenuItems.Controls.Add(this.menuPage1);
             this.pageDesignMenuItems.Flags = 65534;
             this.pageDesignMenuItems.LastVisibleSet = true;
-            this.pageDesignMenuItems.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.pageDesignMenuItems.MinimumSize = new System.Drawing.Size(51, 50);
+            this.pageDesignMenuItems.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pageDesignMenuItems.MinimumSize = new System.Drawing.Size(38, 41);
             this.pageDesignMenuItems.Name = "pageDesignMenuItems";
-            this.pageDesignMenuItems.Size = new System.Drawing.Size(100, 100);
+            this.pageDesignMenuItems.Size = new System.Drawing.Size(75, 81);
             this.pageDesignMenuItems.Text = "Design Menu";
             this.pageDesignMenuItems.TextDescription = "Menu Items appearance and colours";
             this.pageDesignMenuItems.TextTitle = "Menu Items";
@@ -4921,9 +4629,9 @@ namespace PaletteDesigner
             // 
             this.menuPage1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.menuPage1.Location = new System.Drawing.Point(0, 0);
-            this.menuPage1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.menuPage1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.menuPage1.Name = "menuPage1";
-            this.menuPage1.Size = new System.Drawing.Size(100, 100);
+            this.menuPage1.Size = new System.Drawing.Size(75, 81);
             this.menuPage1.TabIndex = 0;
             // 
             // pageDesignToolTips
@@ -4932,10 +4640,9 @@ namespace PaletteDesigner
             this.pageDesignToolTips.Controls.Add(this.toolTipsPage1);
             this.pageDesignToolTips.Flags = 65534;
             this.pageDesignToolTips.LastVisibleSet = true;
-            this.pageDesignToolTips.Margin = new System.Windows.Forms.Padding(4);
-            this.pageDesignToolTips.MinimumSize = new System.Drawing.Size(67, 62);
+            this.pageDesignToolTips.MinimumSize = new System.Drawing.Size(50, 50);
             this.pageDesignToolTips.Name = "pageDesignToolTips";
-            this.pageDesignToolTips.Size = new System.Drawing.Size(133, 123);
+            this.pageDesignToolTips.Size = new System.Drawing.Size(100, 100);
             this.pageDesignToolTips.Text = "Design ToolTips";
             this.pageDesignToolTips.TextDescription = "Tool Tips appearance and colours";
             this.pageDesignToolTips.TextTitle = "Tool Tips";
@@ -4946,9 +4653,9 @@ namespace PaletteDesigner
             // 
             this.toolTipsPage1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolTipsPage1.Location = new System.Drawing.Point(0, 0);
-            this.toolTipsPage1.Margin = new System.Windows.Forms.Padding(5);
+            this.toolTipsPage1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.toolTipsPage1.Name = "toolTipsPage1";
-            this.toolTipsPage1.Size = new System.Drawing.Size(133, 123);
+            this.toolTipsPage1.Size = new System.Drawing.Size(100, 100);
             this.toolTipsPage1.TabIndex = 0;
             // 
             // kryptonHeaderGroupProperties
@@ -4956,13 +4663,11 @@ namespace PaletteDesigner
             this.kryptonHeaderGroupProperties.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonHeaderGroupProperties.HeaderVisibleSecondary = false;
             this.kryptonHeaderGroupProperties.Location = new System.Drawing.Point(0, 0);
-            this.kryptonHeaderGroupProperties.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonHeaderGroupProperties.Name = "kryptonHeaderGroupProperties";
             // 
             // kryptonHeaderGroupProperties.Panel
             // 
             this.kryptonHeaderGroupProperties.Panel.Controls.Add(this.propertyGrid);
-            this.kryptonHeaderGroupProperties.Size = new System.Drawing.Size(664, 735);
+            this.kryptonHeaderGroupProperties.Size = new System.Drawing.Size(499, 577);
             this.kryptonHeaderGroupProperties.TabIndex = 0;
             this.kryptonHeaderGroupProperties.ValuesPrimary.Heading = "Properties";
             this.kryptonHeaderGroupProperties.ValuesPrimary.Image = null;
@@ -4973,9 +4678,8 @@ namespace PaletteDesigner
             this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propertyGrid.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.propertyGrid.Location = new System.Drawing.Point(0, 0);
-            this.propertyGrid.Margin = new System.Windows.Forms.Padding(4);
             this.propertyGrid.Name = "propertyGrid";
-            this.propertyGrid.Size = new System.Drawing.Size(662, 697);
+            this.propertyGrid.Size = new System.Drawing.Size(497, 545);
             this.propertyGrid.TabIndex = 0;
             this.propertyGrid.ToolbarVisible = false;
             this.propertyGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid_PropertyValueChanged);
@@ -5033,13 +4737,11 @@ namespace PaletteDesigner
             // 
             // mainToolStripContainer.ContentPanel
             // 
-            this.mainToolStripContainer.ContentPanel.Margin = new System.Windows.Forms.Padding(4);
-            this.mainToolStripContainer.ContentPanel.Size = new System.Drawing.Size(1544, 805);
+            this.mainToolStripContainer.ContentPanel.Size = new System.Drawing.Size(1162, 642);
             this.mainToolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.mainToolStripContainer.Location = new System.Drawing.Point(0, 0);
-            this.mainToolStripContainer.Margin = new System.Windows.Forms.Padding(4);
             this.mainToolStripContainer.Name = "mainToolStripContainer";
-            this.mainToolStripContainer.Size = new System.Drawing.Size(1544, 830);
+            this.mainToolStripContainer.Size = new System.Drawing.Size(1162, 662);
             this.mainToolStripContainer.TabIndex = 0;
             this.mainToolStripContainer.Text = "toolStripContainer1";
             // 
@@ -5047,7 +4749,6 @@ namespace PaletteDesigner
             // 
             this.kryptonGroup9.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup9.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup9.Name = "kryptonGroup9";
             this.kryptonGroup9.Size = new System.Drawing.Size(100, 47);
             this.kryptonGroup9.TabIndex = 0;
             // 
@@ -5055,9 +4756,13 @@ namespace PaletteDesigner
             // 
             this.kryptonGroup10.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonGroup10.Location = new System.Drawing.Point(0, 0);
-            this.kryptonGroup10.Name = "kryptonGroup10";
             this.kryptonGroup10.Size = new System.Drawing.Size(100, 49);
             this.kryptonGroup10.TabIndex = 0;
+            // 
+            // kryptonManager
+            // 
+            this.kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+            this.kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
             // 
             // kryptonPage1
             // 
@@ -5082,19 +4787,60 @@ namespace PaletteDesigner
             this.kryptonCheckSetLabels.CheckedButton = this.labelsPanelClient;
             this.kryptonCheckSetLabels.CheckedButtonChanged += new System.EventHandler(this.KryptonCheckSetLabels_CheckedButtonChanged);
             // 
+            // kryptonDataGridViewTextBoxColumn1
+            // 
+            this.kryptonDataGridViewTextBoxColumn1.DataPropertyName = "Column1";
+            this.kryptonDataGridViewTextBoxColumn1.HeaderText = "Column1";
+            this.kryptonDataGridViewTextBoxColumn1.Name = "kryptonDataGridViewTextBoxColumn1";
+            this.kryptonDataGridViewTextBoxColumn1.Width = 75;
+            // 
+            // kryptonDataGridViewTextBoxColumn2
+            // 
+            this.kryptonDataGridViewTextBoxColumn2.DataPropertyName = "Column2";
+            this.kryptonDataGridViewTextBoxColumn2.HeaderText = "Column2";
+            this.kryptonDataGridViewTextBoxColumn2.Name = "kryptonDataGridViewTextBoxColumn2";
+            this.kryptonDataGridViewTextBoxColumn2.Width = 75;
+            // 
+            // kryptonDataGridViewTextBoxColumn3
+            // 
+            this.kryptonDataGridViewTextBoxColumn3.DataPropertyName = "Column3";
+            this.kryptonDataGridViewTextBoxColumn3.HeaderText = "Column3";
+            this.kryptonDataGridViewTextBoxColumn3.Name = "kryptonDataGridViewTextBoxColumn3";
+            this.kryptonDataGridViewTextBoxColumn3.Width = 75;
+            // 
+            // kryptonDataGridViewTextBoxColumn4
+            // 
+            this.kryptonDataGridViewTextBoxColumn4.DataPropertyName = "Column1";
+            this.kryptonDataGridViewTextBoxColumn4.HeaderText = "Column1";
+            this.kryptonDataGridViewTextBoxColumn4.Name = "kryptonDataGridViewTextBoxColumn4";
+            this.kryptonDataGridViewTextBoxColumn4.Width = 75;
+            // 
+            // kryptonDataGridViewTextBoxColumn5
+            // 
+            this.kryptonDataGridViewTextBoxColumn5.DataPropertyName = "Column2";
+            this.kryptonDataGridViewTextBoxColumn5.HeaderText = "Column2";
+            this.kryptonDataGridViewTextBoxColumn5.Name = "kryptonDataGridViewTextBoxColumn5";
+            this.kryptonDataGridViewTextBoxColumn5.Width = 75;
+            // 
+            // kryptonDataGridViewTextBoxColumn6
+            // 
+            this.kryptonDataGridViewTextBoxColumn6.DataPropertyName = "Column3";
+            this.kryptonDataGridViewTextBoxColumn6.HeaderText = "Column3";
+            this.kryptonDataGridViewTextBoxColumn6.Name = "kryptonDataGridViewTextBoxColumn6";
+            this.kryptonDataGridViewTextBoxColumn6.Width = 75;
+            // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1544, 830);
+            this.ClientSize = new System.Drawing.Size(1162, 662);
             this.Controls.Add(this.kryptonPanelMainFill);
             this.Controls.Add(this.kryptonNavigatorTop);
             this.Controls.Add(this.mainMenuStrip);
             this.Controls.Add(this.mainToolStripContainer);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.mainMenuStrip;
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(541, 447);
+            this.MinimumSize = new System.Drawing.Size(410, 371);
             this.Name = "MainForm";
             this.Text = "Palette Designer";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
@@ -5725,5 +5471,11 @@ namespace PaletteDesigner
         private ToolStripMenuItem settingsToolStripMenuItem;
         private ToolStripMenuItem launchPaletteUpgradeToolToolStripMenuItem;
         private ToolStripSeparator toolStripMenuItem2;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn4;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn5;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn6;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn1;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn2;
+        private KryptonDataGridViewTextBoxColumn kryptonDataGridViewTextBoxColumn3;
     }
 }

--- a/Applications/Source/Palette Designer/MainForm.cs
+++ b/Applications/Source/Palette Designer/MainForm.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -42,6 +42,8 @@ namespace PaletteDesigner
             _chromeRibbon = new FormChromeRibbon();
 
             _recentlyUsedDocumentsManager = new MostRecentlyUsedDocumentsManager(recentThemesToolStripMenuItem, "Krypton Palette Designer", MyOwnRecentPaletteFileGotClicked_Handler, MyOwnRecentPaletteFilesGotCleared_Handler);
+
+            KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
 
             _applyPalettesToBases =
             [
@@ -502,10 +504,6 @@ namespace PaletteDesigner
             buttonsPage1.ApplyPalette(_palette);
 
             UpdateChromeTMS();
-
-            // Hack until the pages are separated out:
-            var backClr = _palette.GetBackColor1(PaletteBackStyle.PanelClient, PaletteState.Normal);
-            _applyPalettesToPages.ForEach(pg => pg.StateCommon!.Page.Color1 = backClr);
         }
 
         private void UpdateChromeTMS()
@@ -645,8 +643,8 @@ namespace PaletteDesigner
             kryptonNavigatorDesign.Button.ButtonDisplayLogic = ButtonDisplayLogic.None;
 
             // Define initial display pages
-            kryptonNavigatorTop.SelectedPage = pageTopButtons;
-            kryptonNavigatorDesign.SelectedPage = pageDesignButtons;
+            kryptonNavigatorTop.SelectedPage = pageTopRibbon;
+            kryptonNavigatorDesign.SelectedPage = pageDesignRibbon;
 
             CreateNewPalette();
         }
@@ -977,6 +975,24 @@ namespace PaletteDesigner
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e) => _settingsManager.SaveSettings();
 
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
+            base.OnFormClosed(e);
+        }
+
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
+        {
+            if (_palette == null)
+            {
+                return;
+            }
+
+            _palette.BasePalette = KryptonManager.CurrentGlobalPalette;
+
+            ApplyPalette();
+        }
+
         private void LaunchPaletteUpgradeToolToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var paletteUpgradeTool = new FormPaletteUpgradeTool();
@@ -988,7 +1004,7 @@ namespace PaletteDesigner
         {
             var controlPanel = new SettingsControlPanel();
 
-            controlPanel.Show();
+            controlPanel.Show(this);
         }
 
         private void propertyGrid_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)

--- a/Applications/Source/Palette Designer/MainForm.cs
+++ b/Applications/Source/Palette Designer/MainForm.cs
@@ -1,12 +1,10 @@
 ﻿#region BSD License
 /*
- *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
- *
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/MainForm.resx
+++ b/Applications/Source/Palette Designer/MainForm.resx
@@ -1782,7 +1782,7 @@
 </value>
   </data>
   <metadata name="dataSetGrid.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>583, 17</value>
+    <value>794, 27</value>
   </metadata>
   <data name="kryptonGridList.ImageLarge" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -5246,13 +5246,13 @@
 </value>
   </data>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>143, 17</value>
+    <value>196, 22</value>
   </metadata>
   <metadata name="kryptonCheckSetLabels.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>275, 17</value>
+    <value>382, 25</value>
   </metadata>
   <metadata name="kryptonCheckSet1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>442, 17</value>
+    <value>606, 24</value>
   </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Applications/Source/Palette Designer/Pages/BAse.cs
+++ b/Applications/Source/Palette Designer/Pages/BAse.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Pages/BreadCrumbPage.cs
+++ b/Applications/Source/Palette Designer/Pages/BreadCrumbPage.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Pages/ButtonsPage.cs
+++ b/Applications/Source/Palette Designer/Pages/ButtonsPage.cs
@@ -1,6 +1,6 @@
 ﻿/*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
  */
 
 using Krypton.Toolkit;

--- a/Applications/Source/Palette Designer/Pages/InputControls.cs
+++ b/Applications/Source/Palette Designer/Pages/InputControls.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Pages/MenuPage.cs
+++ b/Applications/Source/Palette Designer/Pages/MenuPage.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Pages/ToolTipsPage.cs
+++ b/Applications/Source/Palette Designer/Pages/ToolTipsPage.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Pages/TrackBar.cs
+++ b/Applications/Source/Palette Designer/Pages/TrackBar.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Program.cs
+++ b/Applications/Source/Palette Designer/Program.cs
@@ -1,25 +1,41 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *
  */
 #endregion
+
+using System.Runtime.InteropServices;
 
 namespace PaletteDesigner
 {
     internal static class Program
     {
+#if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+        [DllImport("user32.dll")]
+        private static extern bool SetProcessDPIAware();
+#endif
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         private static void Main()
         {
+            // Enable High-DPI support for Windows Forms
+#if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+            if (Environment.OSVersion.Version.Major >= 6)
+            {
+                SetProcessDPIAware();
+            }
+#else
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+#endif
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new MainForm());

--- a/Applications/Source/Palette Designer/Program.cs
+++ b/Applications/Source/Palette Designer/Program.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion
@@ -16,7 +16,7 @@ namespace PaletteDesigner
 {
     internal static class Program
     {
-#if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+#if NETFRAMEWORK
         [DllImport("user32.dll")]
         private static extern bool SetProcessDPIAware();
 #endif
@@ -27,7 +27,7 @@ namespace PaletteDesigner
         private static void Main()
         {
             // Enable High-DPI support for Windows Forms
-#if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+#if NETFRAMEWORK
             if (Environment.OSVersion.Version.Major >= 6)
             {
                 SetProcessDPIAware();
@@ -35,7 +35,6 @@ namespace PaletteDesigner
 #else
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
 #endif
-
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new MainForm());

--- a/Applications/Source/Palette Designer/Properties/AssemblyInfo.cs
+++ b/Applications/Source/Palette Designer/Properties/AssemblyInfo.cs
@@ -1,12 +1,10 @@
 ﻿#region BSD License
 /*
- * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 
@@ -18,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("100.24.11.327")]
 [assembly: AssemblyFileVersion("100.24.11.327")]
 [assembly: AssemblyInformationalVersion("100.24.11.327")]
-[assembly: AssemblyCopyright("© Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024.")]
+[assembly: AssemblyCopyright("© Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025.")]
 [assembly: AssemblyProduct("Palette Designer")]
 [assembly: AssemblyTitle("Palette Designer")]
 [assembly: AssemblyCompany("Component Factory")]

--- a/Applications/Source/Palette Designer/SettingsControlPanel.cs
+++ b/Applications/Source/Palette Designer/SettingsControlPanel.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
  */
 #endregion
 
@@ -32,6 +32,9 @@ namespace PaletteDesigner
             AcceptButton = kbtnOk;
 
             CancelButton = kbtnCancel;
+
+            // Ensure the dialog buttons close the panel when modeless
+            kbtnCancel.Click += KbtnCancel_Click;
         }
 
         private void SettingsControlPanel_Load(object sender, EventArgs e)
@@ -77,18 +80,57 @@ namespace PaletteDesigner
 
         private void kbtnReset_Click(object sender, EventArgs e)
         {
-            _settingsManager.ResetSettings(_settingsManager.GetAskForSaveConfirmation());
+            var ask = _settingsManager.GetAskForSaveConfirmation();
+
+            if (ask && TopMost)
+            {
+                bool oldTopMost = TopMost;
+                try
+                {
+                    TopMost = false;
+                    _settingsManager.ResetSettings(this, true);
+                }
+                finally
+                {
+                    TopMost = oldTopMost;
+                }
+            }
+            else
+            {
+                _settingsManager.ResetSettings(this, ask);
+            }
 
             EnableResetButton(true);
         }
 
         private void kbtnOk_Click(object sender, EventArgs e)
         {
-            _settingsManager.SaveSettings(_settingsManager.GetAskForSaveConfirmation());
 
-            DialogResult = DialogResult.OK;
+            var ask = _settingsManager.GetAskForSaveConfirmation();
+
+            if (ask && TopMost)
+            {
+                bool oldTopMost = TopMost;
+                try
+                {
+                    TopMost = false;
+                    _settingsManager.SaveSettings(this, true);
+                }
+                finally
+                {
+                    TopMost = oldTopMost;
+                }
+            }
+            else
+            {
+                _settingsManager.SaveSettings(this, ask);
+            }
+
+            Close();
         }
 
         private void EnableResetButton(bool enable) => kbtnReset.Enabled = enable;
+
+        private void KbtnCancel_Click(object sender, EventArgs e) => Close();
     }
 }

--- a/Applications/Source/Palette Designer/SettingsControlPanel.cs
+++ b/Applications/Source/Palette Designer/SettingsControlPanel.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Applications/Source/Palette Designer/Utilities/MostRecentlyUsedDocumentsManager.cs
+++ b/Applications/Source/Palette Designer/Utilities/MostRecentlyUsedDocumentsManager.cs
@@ -1,8 +1,8 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -252,7 +252,7 @@ namespace PaletteDesigner
         }
         #endregion
 
-        #region Constructor        
+        #region Constructor
         /// <summary>
         /// Initializes a new instance of the <see cref="MostRecentlyUsedDocumentsManager"/> class.
         /// </summary>

--- a/Applications/Source/Palette Designer/Utilities/PaletteUpgradeUtilities.cs
+++ b/Applications/Source/Palette Designer/Utilities/PaletteUpgradeUtilities.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2023. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Applications/Source/Palette Designer/Utilities/SettingsManager.cs
+++ b/Applications/Source/Palette Designer/Utilities/SettingsManager.cs
@@ -1,11 +1,17 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *
  */
 #endregion
+
+// @tobitege: remove this and related code once Input- and MessageBox visuals are fixed!
+// This define will show standard MessageBoxes instead of KryptonMessageBoxes.
+#define USE_SYSTEM_MESSAGEBOX
+
+using PaletteDesigner.Properties;
 
 namespace PaletteDesigner
 {
@@ -13,7 +19,7 @@ namespace PaletteDesigner
     {
         #region Instance Fields
 
-        private readonly Settings _settings = null;
+        private readonly Settings _settings = Settings.Default;
 
         #endregion
 
@@ -22,7 +28,7 @@ namespace PaletteDesigner
         /// <summary>Initializes a new instance of the <see cref="SettingsManager" /> class.</summary>
         public SettingsManager()
         {
-            _settings = new Settings();
+            _settings = Settings.Default;
         }
 
         #endregion
@@ -83,16 +89,28 @@ namespace PaletteDesigner
 
         #region Public
 
-        /// <summary>Saves the settings.</summary>
-        /// <param name="useConfirmation">if set to <c>true</c> [use confirmation].</param>
-        public void SaveSettings(bool useConfirmation = false)
+        /// <summary>
+        /// Saves the settings, supplying an owner window so any confirmation dialog appears on top.
+        /// </summary>
+        /// <param name="owner">Owner window for the message box.</param>
+        /// <param name="useConfirmation">Whether to prompt the user for confirmation.</param>
+        public void SaveSettings(IWin32Window owner, bool useConfirmation = false)
         {
             if (useConfirmation)
             {
-                DialogResult result = KryptonMessageBox.Show("Do you want to save these settings with the current values?",
+#if USE_SYSTEM_MESSAGEBOX
+                DialogResult result = MessageBox.Show(owner,
+                    "Do you want to save these settings with the current values?",
+                    "Save Settings",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question);
+#else
+                DialogResult result = KryptonMessageBox.Show(owner,
+                    "Do you want to save these settings with the current values?",
                     "Save Settings",
                     KryptonMessageBoxButtons.YesNo,
                     KryptonMessageBoxIcon.Question);
+#endif
 
                 if (result == DialogResult.Yes)
                 {
@@ -105,16 +123,28 @@ namespace PaletteDesigner
             }
         }
 
-        /// <summary>Resets the settings.</summary>
-        /// <param name="useConfirmation">if set to <c>true</c> [use confirmation].</param>
-        public void ResetSettings(bool useConfirmation = false)
+        /// <summary>
+        /// Resets the settings with an owner window for the confirmation dialog.
+        /// </summary>
+        /// <param name="owner">Owner window for the message box.</param>
+        /// <param name="useConfirmation">Whether to prompt the user for confirmation.</param>
+        public void ResetSettings(IWin32Window owner, bool useConfirmation = false)
         {
             if (useConfirmation)
             {
-                DialogResult result = KryptonMessageBox.Show("Do you want to reset these settings with the default values?",
+#if USE_SYSTEM_MESSAGEBOX
+                DialogResult result = MessageBox.Show(owner,
+                    "Do you want to reset these settings with the default values?",
+                    "Reset Settings",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question);
+#else
+                DialogResult result = KryptonMessageBox.Show(owner,
+                    "Do you want to reset these settings with the default values?",
                     "Reset Settings",
                     KryptonMessageBoxButtons.YesNo,
                     KryptonMessageBoxIcon.Question);
+#endif
 
                 if (result == DialogResult.Yes)
                 {
@@ -140,7 +170,21 @@ namespace PaletteDesigner
                 SetUpgradeOnImport(false);
             }
 
-            SaveSettings(useConfirmation);
+            SaveSettings(owner, useConfirmation);
+        }
+
+        /// <summary>Saves the settings.</summary>
+        /// <param name="useConfirmation">if set to <c>true</c> [use confirmation].</param>
+        public void SaveSettings(bool useConfirmation = false)
+        {
+            SaveSettings(owner: null, useConfirmation);
+        }
+
+        /// <summary>Resets the settings.</summary>
+        /// <param name="useConfirmation">if set to <c>true</c> [use confirmation].</param>
+        public void ResetSettings(bool useConfirmation = false)
+        {
+            ResetSettings(owner: null, useConfirmation);
         }
 
         #endregion

--- a/Applications/Source/Palette Designer/Utilities/SettingsManager.cs
+++ b/Applications/Source/Palette Designer/Utilities/SettingsManager.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion
@@ -20,16 +20,6 @@ namespace PaletteDesigner
         #region Instance Fields
 
         private readonly Settings _settings = Settings.Default;
-
-        #endregion
-
-        #region Identity
-
-        /// <summary>Initializes a new instance of the <see cref="SettingsManager" /> class.</summary>
-        public SettingsManager()
-        {
-            _settings = Settings.Default;
-        }
 
         #endregion
 

--- a/Applications/Source/Palette Designer/app.manifest
+++ b/Applications/Source/Palette Designer/app.manifest
@@ -5,14 +5,14 @@
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
         <!-- UAC Manifest Options
-             If you want to change the Windows User Account Control level replace the 
+             If you want to change the Windows User Account Control level replace the
              requestedExecutionLevel node with one of the following.
 
         <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
         <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
         <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
 
-            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
@@ -46,19 +46,18 @@
   </compatibility>
 
   <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
-       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
-       
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config.
+
        Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-  
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
-  
+
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/GlobalUsings.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/GlobalUsings.cs
@@ -1,7 +1,7 @@
 #region BSD License
 /*
 *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
-*  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2024. All rights reserved.
+*  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2025. All rights reserved.
 */
 #endregion
 

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Program.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Program.cs
@@ -5,20 +5,21 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion
+
 using System.Runtime.InteropServices;
 
 namespace PaletteUpgradeTool
 {
     internal static class Program
     {
-    #if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+#if NETFRAMEWORK
         [DllImport("user32.dll")]
         private static extern bool SetProcessDPIAware();
-    #endif
+#endif
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
@@ -26,14 +27,14 @@ namespace PaletteUpgradeTool
         private static void Main()
         {
             // Enable High-DPI support for Windows Forms
-    #if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+#if NETFRAMEWORK
             if (Environment.OSVersion.Version.Major >= 6)
             {
                 SetProcessDPIAware();
             }
-    #else
+#else
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
-    #endif
+#endif
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new UI.PaletteUpgradeToolOld());

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Program.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Program.cs
@@ -1,25 +1,39 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved.
+ *
  */
 #endregion
+using System.Runtime.InteropServices;
 
 namespace PaletteUpgradeTool
 {
-    static class Program
+    internal static class Program
     {
+    #if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+        [DllImport("user32.dll")]
+        private static extern bool SetProcessDPIAware();
+    #endif
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        private static void Main()
         {
+            // Enable High-DPI support for Windows Forms
+    #if NET48 || NET481 || NET472 || NET471 || NET47 || NET462 || NET461 || NET46
+            if (Environment.OSVersion.Version.Major >= 6)
+            {
+                SetProcessDPIAware();
+            }
+    #else
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    #endif
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new UI.PaletteUpgradeToolOld());

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Properties/AssemblyInfo.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  *  
  */
 #endregion
@@ -47,4 +47,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("100.24.11.327")]
 [assembly: AssemblyFileVersion("100.24.11.327")]
 [assembly: NeutralResourcesLanguage("en-US")]
-

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeTool.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeTool.cs
@@ -1,7 +1,10 @@
 ﻿#region BSD License
 /*
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolOld.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolOld.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2025. All rights reserved. 
  *  
  */
 #endregion

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolOptions.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolOptions.cs
@@ -1,7 +1,10 @@
 ﻿#region BSD License
 /*
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolTest.cs
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/UI/PaletteUpgradeToolTest.cs
@@ -1,7 +1,10 @@
 ﻿#region BSD License
 /*
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/app.manifest
+++ b/Applications/Source/Palette Upgrade Tool/Palette Upgrade Tool/app.manifest
@@ -5,14 +5,14 @@
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
         <!-- UAC Manifest Options
-             If you want to change the Windows User Account Control level replace the 
+             If you want to change the Windows User Account Control level replace the
              requestedExecutionLevel node with one of the following.
 
         <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
         <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
         <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
 
-            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
@@ -46,19 +46,18 @@
   </compatibility>
 
   <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
-       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
-       
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config.
+
        Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-  
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
-  
+
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
- Improved DPI handling across frameworks for both apps
- Fix: Options|Settings dialog would get the app stuck on "Ok" click if confirmation checkbox was checked
- Fix: same dialog wouldn't close on Cancel
- Fix: palette upgrade page had wrong target filename version (always +1 too high)
- Fix: theme switching now correctly propagates it inside MainForm.cs so that all pages get themed correctly.
- Refactored FormPaletteUpgradeTool.cs to enhance XML transformation logic and improve resource management.
- Fix: added new browse buttons for input and output file selection in the upgrade tool (old buttonSpecs errored).
- Updated SettingsManager.cs to streamline settings management with confirmation dialogs.
- Code cleanup in several MainForm methods (all C# 7.3 compatible).

Note: the Toolkit's alpha branch currently has visual display issues for e.g. the KryptonMessageBox, which makes it hard currently to know what is shown (PR already submitted)

This is a first "cleanup" before I'd add the PaletteViewer in followup PR.